### PR TITLE
feat: add new player props

### DIFF
--- a/android/src/main/java/com/tpstreams/TPStreamsRNPlayerView.kt
+++ b/android/src/main/java/com/tpstreams/TPStreamsRNPlayerView.kt
@@ -19,6 +19,10 @@ class TPStreamsRNPlayerView(context: ThemedReactContext) : FrameLayout(context) 
 
     private var videoId: String? = null
     private var accessToken: String? = null
+    private var shouldAutoPlay: Boolean = true
+    private var startAt: Long = 0
+    private var showDefaultCaptions: Boolean = false
+    private var enableDownload: Boolean = false
 
     init {
         addView(playerView, LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT))
@@ -50,21 +54,69 @@ class TPStreamsRNPlayerView(context: ThemedReactContext) : FrameLayout(context) 
     }
 
     fun setVideoId(videoId: String?) {
-        this.videoId = videoId
-        tryCreatePlayer()
+        if (this.videoId != videoId) {
+            this.videoId = videoId
+            tryCreatePlayer()
+        }
     }
 
     fun setAccessToken(accessToken: String?) {
-        this.accessToken = accessToken
-        tryCreatePlayer()
+        if (this.accessToken != accessToken) {
+            this.accessToken = accessToken
+            tryCreatePlayer()
+        }
+    }
+
+    fun setShouldAutoPlay(shouldAutoPlay: Boolean) {
+        if (this.shouldAutoPlay != shouldAutoPlay) {
+            this.shouldAutoPlay = shouldAutoPlay
+            tryCreatePlayer()
+        }
+    }
+
+    fun setStartAt(startAt: Long) {
+        if (this.startAt != startAt) {
+            this.startAt = startAt
+            tryCreatePlayer()
+        }
+    }
+
+    fun setShowDefaultCaptions(showDefaultCaptions: Boolean) {
+        if (this.showDefaultCaptions != showDefaultCaptions) {
+            this.showDefaultCaptions = showDefaultCaptions
+            tryCreatePlayer()
+        }
+    }
+
+    fun setEnableDownload(enableDownload: Boolean) {
+        if (this.enableDownload != enableDownload) {
+            this.enableDownload = enableDownload
+            tryCreatePlayer()
+        }
     }
 
     private fun tryCreatePlayer() {
         if (videoId.isNullOrEmpty() || accessToken.isNullOrEmpty()) return
-        if (player != null) return
+
+        if (player != null) {
+            try {
+                player?.release()
+                player = null
+            } catch (e: Exception) {
+                Log.e("TPStreamsRN", "Error releasing player", e)
+            }
+        }
 
         try {
-            player = TPStreamsPlayer.create(context, videoId!!, accessToken!!)
+            player = TPStreamsPlayer.create(
+                context, 
+                videoId!!, 
+                accessToken!!, 
+                shouldAutoPlay, 
+                startAt,
+                enableDownload, 
+                showDefaultCaptions 
+            )
             
             // Add player event listeners
             player?.addListener(createPlayerListener())

--- a/android/src/main/java/com/tpstreams/TPStreamsRNPlayerViewManager.kt
+++ b/android/src/main/java/com/tpstreams/TPStreamsRNPlayerViewManager.kt
@@ -62,6 +62,26 @@ class TPStreamsRNPlayerViewManager : SimpleViewManager<TPStreamsRNPlayerView>(),
     view.setAccessToken(accessToken)
   }
 
+  @ReactProp(name = "shouldAutoPlay", defaultBoolean = true)
+  override fun setShouldAutoPlay(view: TPStreamsRNPlayerView, shouldAutoPlay: Boolean) {
+    view.setShouldAutoPlay(shouldAutoPlay)
+  }
+  
+  @ReactProp(name = "startAt")
+  override fun setStartAt(view: TPStreamsRNPlayerView, startAt: Double) {
+    view.setStartAt(startAt.toLong())
+  }
+
+  @ReactProp(name = "showDefaultCaptions", defaultBoolean = false)
+  override fun setShowDefaultCaptions(view: TPStreamsRNPlayerView, showDefaultCaptions: Boolean) {
+    view.setShowDefaultCaptions(showDefaultCaptions)
+  }
+
+  @ReactProp(name = "enableDownload", defaultBoolean = false)
+  override fun setEnableDownload(view: TPStreamsRNPlayerView, enableDownload: Boolean) {
+    view.setEnableDownload(enableDownload)
+  }
+
   // Command implementations
   override fun play(view: TPStreamsRNPlayerView) {
     view.play()

--- a/src/TPStreamsPlayer.tsx
+++ b/src/TPStreamsPlayer.tsx
@@ -35,6 +35,10 @@ export interface TPStreamsPlayerRef {
 export interface TPStreamsPlayerProps extends ViewProps {
   videoId?: string;
   accessToken?: string;
+  shouldAutoPlay?: boolean;
+  startAt?: number;
+  enableDownload?: boolean;
+  showDefaultCaptions?: boolean;
   onPlayerStateChanged?: (state: number) => void;
   onIsPlayingChanged?: (isPlaying: boolean) => void;
   onPlaybackSpeedChanged?: (speed: number) => void;
@@ -57,6 +61,10 @@ const TPStreamsPlayerView = forwardRef<
   const {
     videoId,
     accessToken,
+    shouldAutoPlay,
+    startAt,
+    enableDownload,
+    showDefaultCaptions,
     style,
     onPlayerStateChanged,
     onIsPlayingChanged,
@@ -203,6 +211,10 @@ const TPStreamsPlayerView = forwardRef<
     ...restProps,
     videoId,
     accessToken,
+    shouldAutoPlay,
+    startAt,
+    enableDownload,
+    showDefaultCaptions,
     style,
     onCurrentPosition,
     onDuration,

--- a/src/TPStreamsPlayerViewNativeComponent.ts
+++ b/src/TPStreamsPlayerViewNativeComponent.ts
@@ -18,6 +18,10 @@ export interface ErrorEvent {
 export interface NativeProps extends ViewProps {
   videoId?: string;
   accessToken?: string;
+  shouldAutoPlay?: boolean;
+  startAt?: Double;
+  enableDownload?: boolean;
+  showDefaultCaptions?: boolean;
 
   // Event props for receiving data from native methods
   onCurrentPosition?: DirectEventHandler<{ position: Double }>;


### PR DESCRIPTION
- Added `autoplay` prop to control automatic playback
- Added `startAt` prop to begin playback at a specific timestamp
- Added `showDefaultCaptions` prop to enable the first available caption track
- Added `enableDownload` prop to toggle download button visibility
