### PR TITLE
feat: add player control props

### DIFF
--- a/android/src/main/java/com/tpstreams/TPStreamsRNPlayerView.kt
+++ b/android/src/main/java/com/tpstreams/TPStreamsRNPlayerView.kt
@@ -19,6 +19,10 @@ class TPStreamsRNPlayerView(context: ThemedReactContext) : FrameLayout(context) 
 
     private var videoId: String? = null
     private var accessToken: String? = null
+    private var shouldAutoPlay: Boolean = true
+    private var startAt: Long = 0
+    private var showDefaultCaptions: Boolean = false
+    private var enableDownload: Boolean = false
 
     init {
         addView(playerView, LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT))
@@ -51,20 +55,42 @@ class TPStreamsRNPlayerView(context: ThemedReactContext) : FrameLayout(context) 
 
     fun setVideoId(videoId: String?) {
         this.videoId = videoId
-        tryCreatePlayer()
     }
 
     fun setAccessToken(accessToken: String?) {
         this.accessToken = accessToken
-        tryCreatePlayer()
     }
 
-    private fun tryCreatePlayer() {
+    fun setShouldAutoPlay(shouldAutoPlay: Boolean) {
+        this.shouldAutoPlay = shouldAutoPlay
+    }
+
+    fun setStartAt(startAt: Long) {
+        this.startAt = startAt
+    }
+
+    fun setShowDefaultCaptions(showDefaultCaptions: Boolean) {
+        this.showDefaultCaptions = showDefaultCaptions
+    }
+
+    fun setEnableDownload(enableDownload: Boolean) {
+        this.enableDownload = enableDownload
+    }
+
+    fun tryCreatePlayer() {
         if (videoId.isNullOrEmpty() || accessToken.isNullOrEmpty()) return
         if (player != null) return
 
         try {
-            player = TPStreamsPlayer.create(context, videoId!!, accessToken!!)
+            player = TPStreamsPlayer.create(
+                context, 
+                videoId!!, 
+                accessToken!!, 
+                shouldAutoPlay, 
+                startAt,
+                enableDownload, 
+                showDefaultCaptions 
+            )
             
             // Add player event listeners
             player?.addListener(createPlayerListener())

--- a/android/src/main/java/com/tpstreams/TPStreamsRNPlayerViewManager.kt
+++ b/android/src/main/java/com/tpstreams/TPStreamsRNPlayerViewManager.kt
@@ -62,6 +62,26 @@ class TPStreamsRNPlayerViewManager : SimpleViewManager<TPStreamsRNPlayerView>(),
     view.setAccessToken(accessToken)
   }
 
+  @ReactProp(name = "shouldAutoPlay")
+  override fun setShouldAutoPlay(view: TPStreamsRNPlayerView, shouldAutoPlay: Boolean) {
+    view.setShouldAutoPlay(shouldAutoPlay)
+  }
+
+  @ReactProp(name = "startAt")
+  override fun setStartAt(view: TPStreamsRNPlayerView, startAt: Double) {
+    view.setStartAt(startAt.toLong())
+  }
+
+  @ReactProp(name = "showDefaultCaptions")
+  override fun setShowDefaultCaptions(view: TPStreamsRNPlayerView, showDefaultCaptions: Boolean) {
+    view.setShowDefaultCaptions(showDefaultCaptions)
+  }
+
+  @ReactProp(name = "enableDownload")
+  override fun setEnableDownload(view: TPStreamsRNPlayerView, enableDownload: Boolean) {
+    view.setEnableDownload(enableDownload)
+  }
+
   // Command implementations
   override fun play(view: TPStreamsRNPlayerView) {
     view.play()
@@ -93,5 +113,10 @@ class TPStreamsRNPlayerViewManager : SimpleViewManager<TPStreamsRNPlayerView>(),
   
   override fun getPlaybackSpeed(view: TPStreamsRNPlayerView) {
     view.getPlaybackSpeed()
+  }
+  
+  override fun onAfterUpdateTransaction(view: TPStreamsRNPlayerView) {
+    super.onAfterUpdateTransaction(view)
+    view.tryCreatePlayer()
   }
 }

--- a/src/TPStreamsPlayer.tsx
+++ b/src/TPStreamsPlayer.tsx
@@ -35,6 +35,10 @@ export interface TPStreamsPlayerRef {
 export interface TPStreamsPlayerProps extends ViewProps {
   videoId?: string;
   accessToken?: string;
+  shouldAutoPlay?: boolean;
+  startAt?: number;
+  enableDownload?: boolean;
+  showDefaultCaptions?: boolean;
   onPlayerStateChanged?: (state: number) => void;
   onIsPlayingChanged?: (isPlaying: boolean) => void;
   onPlaybackSpeedChanged?: (speed: number) => void;
@@ -57,6 +61,10 @@ const TPStreamsPlayerView = forwardRef<
   const {
     videoId,
     accessToken,
+    shouldAutoPlay,
+    startAt,
+    enableDownload,
+    showDefaultCaptions,
     style,
     onPlayerStateChanged,
     onIsPlayingChanged,
@@ -203,6 +211,10 @@ const TPStreamsPlayerView = forwardRef<
     ...restProps,
     videoId,
     accessToken,
+    shouldAutoPlay,
+    startAt,
+    enableDownload,
+    showDefaultCaptions,
     style,
     onCurrentPosition,
     onDuration,

--- a/src/TPStreamsPlayerViewNativeComponent.ts
+++ b/src/TPStreamsPlayerViewNativeComponent.ts
@@ -18,6 +18,10 @@ export interface ErrorEvent {
 export interface NativeProps extends ViewProps {
   videoId?: string;
   accessToken?: string;
+  shouldAutoPlay?: boolean;
+  startAt?: Double;
+  enableDownload?: boolean;
+  showDefaultCaptions?: boolean;
 
   // Event props for receiving data from native methods
   onCurrentPosition?: DirectEventHandler<{ position: Double }>;


### PR DESCRIPTION
- Added autoplay prop to control automatic playback
- Added startAt prop to begin playback at a specific timestamp
- Added showDefaultCaptions prop to enable the first available caption track
- Added enableDownload prop to toggle download button visibility

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added options to control autoplay, initial playback position, default captions display, and download capability for the player component.
  * These new settings can be configured via component properties for greater customization of playback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->