### PR TITLE
fix: rename getAllDownloadItems to getAllDownloads

### DIFF
--- a/android/src/main/java/com/tpstreams/TPStreamsDownloadModule.kt
+++ b/android/src/main/java/com/tpstreams/TPStreamsDownloadModule.kt
@@ -97,7 +97,7 @@ class TPStreamsDownloadModule(private val reactContext: ReactApplicationContext)
     }
 
     @ReactMethod
-    fun getAllDownloadItems(promise: Promise) {
+    fun getAllDownloads(promise: Promise) {
         try {
             val downloadItems = downloadClient.getAllDownloadItems()
             val result = Arguments.createArray()

--- a/src/TPStreamsDownload.tsx
+++ b/src/TPStreamsDownload.tsx
@@ -40,6 +40,6 @@ export function getDownloadStatus(videoId: string): Promise<string> {
   return TPStreamsDownload.getDownloadStatus(videoId);
 }
 
-export function getAllDownloadItems(): Promise<DownloadItem[]> {
-  return TPStreamsDownload.getAllDownloadItems();
+export function getAllDownloads(): Promise<DownloadItem[]> {
+  return TPStreamsDownload.getAllDownloads();
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -15,7 +15,7 @@ export {
   isDownloading,
   isPaused,
   getDownloadStatus,
-  getAllDownloadItems,
+  getAllDownloads,
   type DownloadItem,
 } from './TPStreamsDownload';
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Renamed all references of the download retrieval function from `getAllDownloadItems` to `getAllDownloads` across the app for consistency. No changes to functionality or behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->