### PR TITLE
feat: add support for downloadMetadata prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ import { TPStreamsPlayerView } from "react-native-tpstreams";
 
 - `enableDownload`: (Optional) Whether to enable download functionality for the video. When set to true, the player will show a download button. Default is false.
 
+- `downloadMetadata`: (Optional) Custom metadata to attach to downloads. Accepts an object with string key-value pairs. This metadata is stored with the download and can be retrieved later. Default is undefined.
+
 ---
 
 ## Downloads
@@ -124,6 +126,7 @@ The download item object (`DownloadItem`) contains information about a downloade
 - `progressPercentage`: Download progress from 0 to 100.
 - `title`: The title of the video Asset.
 - `thumbnailUrl`: URL to the video thumbnail (if available).
+- `metadata`: Custom metadata attached to the download as a JSON string (if provided during download).
 
 ---
 
@@ -179,6 +182,11 @@ function TPStreamsPlayerExample() {
           // Fetch a new token from your server
           const newToken = await getNewTokenForVideo(videoId);
           callback(newToken);
+        }}
+        downloadMetadata={{
+          category: 'educational',
+          subject: 'mathematics',
+          level: 'intermediate'
         }}
       />
       

--- a/android/src/main/java/com/tpstreams/TPStreamsDownloadModule.kt
+++ b/android/src/main/java/com/tpstreams/TPStreamsDownloadModule.kt
@@ -112,11 +112,13 @@ class TPStreamsDownloadModule(private val reactContext: ReactApplicationContext)
                 map.putDouble("progressPercentage", item.progressPercentage.toDouble())
                 map.putString("state", downloadClient.getDownloadStatus(item.assetId))
                 
-                val metadataJson = org.json.JSONObject()
-                item.metadata.forEach { (key, value) ->
-                    metadataJson.put(key, value)
+                try {
+                    val metadataJson = org.json.JSONObject(item.metadata as Map<*, *>)
+                    map.putString("metadata", metadataJson.toString())
+                } catch (e: Exception) {
+                    Log.w(TAG, "Error serializing metadata for item ${item.assetId}: ${e.message}")
+                    map.putString("metadata", "{}")
                 }
-                map.putString("metadata", metadataJson.toString())
                 
                 result.pushMap(map)
             }

--- a/android/src/main/java/com/tpstreams/TPStreamsDownloadModule.kt
+++ b/android/src/main/java/com/tpstreams/TPStreamsDownloadModule.kt
@@ -112,6 +112,12 @@ class TPStreamsDownloadModule(private val reactContext: ReactApplicationContext)
                 map.putDouble("progressPercentage", item.progressPercentage.toDouble())
                 map.putString("state", downloadClient.getDownloadStatus(item.assetId))
                 
+                val metadataJson = org.json.JSONObject()
+                item.metadata.forEach { (key, value) ->
+                    metadataJson.put(key, value)
+                }
+                map.putString("metadata", metadataJson.toString())
+                
                 result.pushMap(map)
             }
             

--- a/android/src/main/java/com/tpstreams/TPStreamsRNPlayerView.kt
+++ b/android/src/main/java/com/tpstreams/TPStreamsRNPlayerView.kt
@@ -23,6 +23,7 @@ class TPStreamsRNPlayerView(context: ThemedReactContext) : FrameLayout(context) 
     private var startAt: Long = 0
     private var showDefaultCaptions: Boolean = false
     private var enableDownload: Boolean = false
+    private var downloadMetadata: Map<String, String>? = null
     private var accessTokenCallback: ((String) -> Unit)? = null
 
     init {
@@ -78,6 +79,10 @@ class TPStreamsRNPlayerView(context: ThemedReactContext) : FrameLayout(context) 
         this.enableDownload = enableDownload
     }
     
+    fun setDownloadMetadata(metadata: Map<String, String>?) {
+        this.downloadMetadata = metadata
+    }
+    
     fun setNewAccessToken(newToken: String) {
         Log.d("TPStreamsRNPlayerView", "Setting new access token")
         accessTokenCallback?.let { callback ->
@@ -98,7 +103,8 @@ class TPStreamsRNPlayerView(context: ThemedReactContext) : FrameLayout(context) 
                 shouldAutoPlay, 
                 startAt,
                 enableDownload, 
-                showDefaultCaptions 
+                showDefaultCaptions,
+                downloadMetadata
             )
             
             player?.listener = object : TPStreamsPlayer.Listener {

--- a/android/src/main/java/com/tpstreams/TPStreamsRNPlayerViewManager.kt
+++ b/android/src/main/java/com/tpstreams/TPStreamsRNPlayerViewManager.kt
@@ -84,6 +84,26 @@ class TPStreamsRNPlayerViewManager : SimpleViewManager<TPStreamsRNPlayerView>(),
     view.setEnableDownload(enableDownload)
   }
 
+  @ReactProp(name = "downloadMetadata")
+  override fun setDownloadMetadata(view: TPStreamsRNPlayerView, metadata: String?) {
+    val metadataMap = if (!metadata.isNullOrEmpty()) {
+      try {
+        val jsonObject = org.json.JSONObject(metadata)
+        val map = mutableMapOf<String, String>()
+        val keys = jsonObject.keys()
+        while (keys.hasNext()) {
+          val key = keys.next()
+          map[key] = jsonObject.getString(key)
+        }
+        map
+      } catch (e: Exception) {
+        android.util.Log.w("TPStreamsRN", "Error parsing download metadata: ${e.message}")
+        null
+      }
+    } else null
+    view.setDownloadMetadata(metadataMap)
+  }
+
   // Command implementations
   override fun play(view: TPStreamsRNPlayerView) {
     view.play()

--- a/android/src/main/java/com/tpstreams/TPStreamsRNPlayerViewManager.kt
+++ b/android/src/main/java/com/tpstreams/TPStreamsRNPlayerViewManager.kt
@@ -89,14 +89,12 @@ class TPStreamsRNPlayerViewManager : SimpleViewManager<TPStreamsRNPlayerView>(),
     val metadataMap = if (!metadata.isNullOrEmpty()) {
       try {
         val jsonObject = org.json.JSONObject(metadata)
-        val map = mutableMapOf<String, String>()
-        val keys = jsonObject.keys()
-        while (keys.hasNext()) {
-          val key = keys.next()
-          map[key] = jsonObject.getString(key)
-        }
+        val map = jsonObject.keys()
+        .asSequence()
+        .associate { it to jsonObject.getString(it) }
+        .toMutableMap()
         map
-      } catch (e: Exception) {
+      } catch (e: org.json.JSONException) {
         android.util.Log.w("TPStreamsRN", "Error parsing download metadata: ${e.message}")
         null
       }

--- a/src/TPStreamsDownload.tsx
+++ b/src/TPStreamsDownload.tsx
@@ -10,6 +10,7 @@ export interface DownloadItem {
   downloadedBytes: number;
   progressPercentage: number;
   state: string;
+  metadata: string;
 }
 
 export function pauseDownload(videoId: string): Promise<void> {

--- a/src/TPStreamsPlayer.tsx
+++ b/src/TPStreamsPlayer.tsx
@@ -39,6 +39,7 @@ export interface TPStreamsPlayerProps extends ViewProps {
   startAt?: number;
   enableDownload?: boolean;
   showDefaultCaptions?: boolean;
+  downloadMetadata?: { [key: string]: string };
   onPlayerStateChanged?: (state: number) => void;
   onIsPlayingChanged?: (isPlaying: boolean) => void;
   onPlaybackSpeedChanged?: (speed: number) => void;
@@ -69,6 +70,7 @@ const TPStreamsPlayerView = forwardRef<
     startAt,
     enableDownload,
     showDefaultCaptions,
+    downloadMetadata,
     style,
     onPlayerStateChanged,
     onIsPlayingChanged,
@@ -236,6 +238,9 @@ const TPStreamsPlayerView = forwardRef<
     startAt,
     enableDownload,
     showDefaultCaptions,
+    downloadMetadata: downloadMetadata
+      ? JSON.stringify(downloadMetadata)
+      : undefined,
     style,
     onCurrentPosition,
     onDuration,

--- a/src/TPStreamsPlayerViewNativeComponent.ts
+++ b/src/TPStreamsPlayerViewNativeComponent.ts
@@ -22,6 +22,7 @@ export interface NativeProps extends ViewProps {
   startAt?: Double;
   enableDownload?: boolean;
   showDefaultCaptions?: boolean;
+  downloadMetadata?: string;
 
   // Event props for receiving data from native methods
   onCurrentPosition?: DirectEventHandler<{ position: Double }>;


### PR DESCRIPTION
- Introduced `downloadMetadata` prop in the player component to allow attaching custom metadata to each download.
- Updated the Android native module to receive, handle, and serialize this metadata.
- Extended the `DownloadItem` interface to include metadata stored as a JSON string.
- Updated documentation to reflect usage of the new `downloadMetadata` feature.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for passing and displaying download metadata within the player component.
  * Users can now access additional metadata associated with downloaded items.
* **Enhancements**
  * Improved integration between the download and player components to handle and transfer metadata seamlessly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->