### PR TITLE
fix: add required NativeEventEmitter methods to prevent warnings

### DIFF
--- a/android/src/main/java/com/tpstreams/TPStreamsDownloadModule.kt
+++ b/android/src/main/java/com/tpstreams/TPStreamsDownloadModule.kt
@@ -53,12 +53,12 @@ class TPStreamsDownloadModule(private val reactContext: ReactApplicationContext)
     }
 
     @ReactMethod
-    fun addListener(eventName: String) {
+    fun addListener(_: String) {
         // Required by NativeEventEmitter - no action needed
     }
 
     @ReactMethod
-    fun removeListeners(count: Int) {
+    fun removeListeners(_: Int) {
         // Required by NativeEventEmitter - no action needed
     }
 

--- a/android/src/main/java/com/tpstreams/TPStreamsDownloadModule.kt
+++ b/android/src/main/java/com/tpstreams/TPStreamsDownloadModule.kt
@@ -52,6 +52,16 @@ class TPStreamsDownloadModule(private val reactContext: ReactApplicationContext)
         }
     }
 
+    @ReactMethod
+    fun addListener(eventName: String) {
+        // Required by NativeEventEmitter - no action needed
+    }
+
+    @ReactMethod
+    fun removeListeners(count: Int) {
+        // Required by NativeEventEmitter - no action needed
+    }
+
     override fun onDownloadsChanged() {
         try {
             val currentDownloads = downloadClient.getAllDownloadItems()


### PR DESCRIPTION
- Previously, using download progress functionality showed warnings about missing `addListener` and `removeListeners` methods. 
- This commit adds these required methods to the Android native module to resolve the NativeEventEmitter warnings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal updates to support compatibility with event handling requirements. No visible changes to app functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->