### PR TITLE
feat: add offlineLicenseExpireTime prop support

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -3,4 +3,4 @@ Tpstreams_minSdkVersion=24
 Tpstreams_targetSdkVersion=34
 Tpstreams_compileSdkVersion=35
 Tpstreams_ndkVersion=27.1.12297006
-Tpstreams_tpstreamsAndroidPlayerVersion=1.0.13
+Tpstreams_tpstreamsAndroidPlayerVersion=1.0.14

--- a/android/src/main/java/com/tpstreams/TPStreamsRNPlayerView.kt
+++ b/android/src/main/java/com/tpstreams/TPStreamsRNPlayerView.kt
@@ -17,6 +17,10 @@ class TPStreamsRNPlayerView(context: ThemedReactContext) : FrameLayout(context) 
     private var player: TPStreamsPlayer? = null
     private val reactContext: ReactContext = context
 
+    companion object {
+        private const val DEFAULT_OFFLINE_LICENSE_EXPIRE_TIME = 15L * 24L * 60L * 60L // 15 days in seconds
+    }
+
     private var videoId: String? = null
     private var accessToken: String? = null
     private var shouldAutoPlay: Boolean = true
@@ -24,6 +28,7 @@ class TPStreamsRNPlayerView(context: ThemedReactContext) : FrameLayout(context) 
     private var showDefaultCaptions: Boolean = false
     private var enableDownload: Boolean = false
     private var downloadMetadata: Map<String, String>? = null
+    private var offlineLicenseExpireTime: Long = DEFAULT_OFFLINE_LICENSE_EXPIRE_TIME
     private var accessTokenCallback: ((String) -> Unit)? = null
 
     init {
@@ -83,6 +88,10 @@ class TPStreamsRNPlayerView(context: ThemedReactContext) : FrameLayout(context) 
         this.downloadMetadata = metadata
     }
     
+    fun setOfflineLicenseExpireTime(expireTime: Long?) {
+        this.offlineLicenseExpireTime = expireTime ?: DEFAULT_OFFLINE_LICENSE_EXPIRE_TIME
+    }
+    
     fun setNewAccessToken(newToken: String) {
         Log.d("TPStreamsRNPlayerView", "Setting new access token")
         accessTokenCallback?.let { callback ->
@@ -104,7 +113,8 @@ class TPStreamsRNPlayerView(context: ThemedReactContext) : FrameLayout(context) 
                 startAt,
                 enableDownload, 
                 showDefaultCaptions,
-                downloadMetadata
+                downloadMetadata,
+                offlineLicenseExpireTime
             )
             
             player?.listener = object : TPStreamsPlayer.Listener {

--- a/android/src/main/java/com/tpstreams/TPStreamsRNPlayerViewManager.kt
+++ b/android/src/main/java/com/tpstreams/TPStreamsRNPlayerViewManager.kt
@@ -84,6 +84,11 @@ class TPStreamsRNPlayerViewManager : SimpleViewManager<TPStreamsRNPlayerView>(),
     view.setEnableDownload(enableDownload)
   }
 
+  @ReactProp(name = "offlineLicenseExpireTime")
+  override fun setOfflineLicenseExpireTime(view: TPStreamsRNPlayerView, expireTime: Double) {
+    view.setOfflineLicenseExpireTime(expireTime.toLong())
+  }
+
   @ReactProp(name = "downloadMetadata")
   override fun setDownloadMetadata(view: TPStreamsRNPlayerView, metadata: String?) {
     val metadataMap = if (!metadata.isNullOrEmpty()) {

--- a/src/TPStreamsPlayer.tsx
+++ b/src/TPStreamsPlayer.tsx
@@ -38,6 +38,7 @@ export interface TPStreamsPlayerProps extends ViewProps {
   shouldAutoPlay?: boolean;
   startAt?: number;
   enableDownload?: boolean;
+  offlineLicenseExpireTime?: number;
   showDefaultCaptions?: boolean;
   downloadMetadata?: { [key: string]: string };
   onPlayerStateChanged?: (state: number) => void;
@@ -69,6 +70,7 @@ const TPStreamsPlayerView = forwardRef<
     shouldAutoPlay,
     startAt,
     enableDownload,
+    offlineLicenseExpireTime,
     showDefaultCaptions,
     downloadMetadata,
     style,
@@ -241,6 +243,7 @@ const TPStreamsPlayerView = forwardRef<
     downloadMetadata: downloadMetadata
       ? JSON.stringify(downloadMetadata)
       : undefined,
+    offlineLicenseExpireTime,
     style,
     onCurrentPosition,
     onDuration,

--- a/src/TPStreamsPlayerViewNativeComponent.ts
+++ b/src/TPStreamsPlayerViewNativeComponent.ts
@@ -21,6 +21,7 @@ export interface NativeProps extends ViewProps {
   shouldAutoPlay?: boolean;
   startAt?: Double;
   enableDownload?: boolean;
+  offlineLicenseExpireTime?: Double;
   showDefaultCaptions?: boolean;
   downloadMetadata?: string;
 


### PR DESCRIPTION
- Add offlineLicenseExpireTime prop to TPStreamsPlayerView component
- Support for setting offline license expiration time in seconds
- Default value of 15 days (1,296,000 seconds) when not provided
- Reorder props to place offlineLicenseExpireTime after enableDownload
- Update TypeScript interfaces and Android native code
- Fix parameter type from nullable to non-nullable Double
- Update README documentation with prop description and example

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for specifying an offline license expiration time for the player component.
  * Introduced a new property to set the offline license expiry duration from the app interface.

* **Chores**
  * Updated the Android player version to 1.0.14.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->