### PR TITLE
feat: implement SwiftUI-based video player with package restructuring

### DIFF
--- a/TPStreams.podspec
+++ b/TPStreams.podspec
@@ -3,7 +3,7 @@ require "json"
 package = JSON.parse(File.read(File.join(__dir__, "package.json")))
 
 Pod::Spec.new do |s|
-  s.name         = "TPStreamsRNPlayerView"
+  s.name         = "TPStreams"
   s.version      = package["version"]
   s.summary      = package["description"]
   s.homepage     = package["homepage"]
@@ -17,8 +17,7 @@ Pod::Spec.new do |s|
   s.private_header_files = "ios/**/*.h"
   
   s.swift_version = '5.0'
-  
-  # Ensure the module is not built as a framework to avoid bridging header conflicts
+
   s.static_framework = true
 
  install_modules_dependencies(s)

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1655,7 +1655,7 @@ PODS:
     - React-perflogger (= 0.79.2)
     - React-utils (= 0.79.2)
   - SocketRocket (0.7.1)
-  - TPStreamsRNPlayerView (0.2.19):
+  - TPStreams (0.2.19):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1753,7 +1753,7 @@ DEPENDENCIES:
   - ReactAppDependencyProvider (from `build/generated/ios`)
   - ReactCodegen (from `build/generated/ios`)
   - ReactCommon/turbomodule/core (from `../node_modules/react-native/ReactCommon`)
-  - TPStreamsRNPlayerView (from `../..`)
+  - TPStreams (from `../..`)
   - Yoga (from `../node_modules/react-native/ReactCommon/yoga`)
 
 SPEC REPOS:
@@ -1900,7 +1900,7 @@ EXTERNAL SOURCES:
     :path: build/generated/ios
   ReactCommon:
     :path: "../node_modules/react-native/ReactCommon"
-  TPStreamsRNPlayerView:
+  TPStreams:
     :path: "../.."
   Yoga:
     :path: "../node_modules/react-native/ReactCommon/yoga"
@@ -1976,7 +1976,7 @@ SPEC CHECKSUMS:
   ReactCodegen: c63eda03ba1d94353fb97b031fc84f75a0d125ba
   ReactCommon: 76d2dc87136d0a667678668b86f0fca0c16fdeb0
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
-  TPStreamsRNPlayerView: eba8348623a5dedea810854798bf4a1b0e782506
+  TPStreams: f0efa248302063a0e1d8aaaf945abd3a14aa1fc9
   Yoga: c758bfb934100bb4bf9cbaccb52557cee35e8bdf
 
 PODFILE CHECKSUM: f32cb87a90d21649523da49ffd05d9f0480c624c

--- a/example/ios/TpstreamsExample.xcodeproj/project.pbxproj
+++ b/example/ios/TpstreamsExample.xcodeproj/project.pbxproj
@@ -7,11 +7,11 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		0C80B921A6F3F58F76C31292 /* libPods-TpstreamsExample.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 5DCACB8F33CDC322A6C60F78 /* libPods-TpstreamsExample.a */; };
 		13B07FBF1A68108700A75B9A /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB51A68108700A75B9A /* Images.xcassets */; };
 		761780ED2CA45674006654EE /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 761780EC2CA45674006654EE /* AppDelegate.swift */; };
 		81AB9BB82411601600AC10FF /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */; };
 		91AD30DC239874A835137420 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB81A68108700A75B9A /* PrivacyInfo.xcprivacy */; };
+		EC87F67C5FEC02D16472B631 /* libPods-TpstreamsExample.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 6D017AD93ABCDFB4212A2153 /* libPods-TpstreamsExample.a */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -19,11 +19,11 @@
 		13B07FB51A68108700A75B9A /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = TpstreamsExample/Images.xcassets; sourceTree = "<group>"; };
 		13B07FB61A68108700A75B9A /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = TpstreamsExample/Info.plist; sourceTree = "<group>"; };
 		13B07FB81A68108700A75B9A /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = PrivacyInfo.xcprivacy; path = TpstreamsExample/PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
-		3B4392A12AC88292D35C810B /* Pods-TpstreamsExample.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TpstreamsExample.debug.xcconfig"; path = "Target Support Files/Pods-TpstreamsExample/Pods-TpstreamsExample.debug.xcconfig"; sourceTree = "<group>"; };
-		5709B34CF0A7D63546082F79 /* Pods-TpstreamsExample.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TpstreamsExample.release.xcconfig"; path = "Target Support Files/Pods-TpstreamsExample/Pods-TpstreamsExample.release.xcconfig"; sourceTree = "<group>"; };
-		5DCACB8F33CDC322A6C60F78 /* libPods-TpstreamsExample.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-TpstreamsExample.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		6D017AD93ABCDFB4212A2153 /* libPods-TpstreamsExample.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-TpstreamsExample.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		761780EC2CA45674006654EE /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AppDelegate.swift; path = TpstreamsExample/AppDelegate.swift; sourceTree = "<group>"; };
 		81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = LaunchScreen.storyboard; path = TpstreamsExample/LaunchScreen.storyboard; sourceTree = "<group>"; };
+		D2798F5D93B5E992C1FB7148 /* Pods-TpstreamsExample.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TpstreamsExample.debug.xcconfig"; path = "Target Support Files/Pods-TpstreamsExample/Pods-TpstreamsExample.debug.xcconfig"; sourceTree = "<group>"; };
+		E5FD7A2F929E72A9B0CE9DD8 /* Pods-TpstreamsExample.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TpstreamsExample.release.xcconfig"; path = "Target Support Files/Pods-TpstreamsExample/Pods-TpstreamsExample.release.xcconfig"; sourceTree = "<group>"; };
 		ED297162215061F000B7C4FE /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
 /* End PBXFileReference section */
 
@@ -32,7 +32,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				0C80B921A6F3F58F76C31292 /* libPods-TpstreamsExample.a in Frameworks */,
+				EC87F67C5FEC02D16472B631 /* libPods-TpstreamsExample.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -55,7 +55,7 @@
 			isa = PBXGroup;
 			children = (
 				ED297162215061F000B7C4FE /* JavaScriptCore.framework */,
-				5DCACB8F33CDC322A6C60F78 /* libPods-TpstreamsExample.a */,
+				6D017AD93ABCDFB4212A2153 /* libPods-TpstreamsExample.a */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -92,8 +92,8 @@
 		BBD78D7AC51CEA395F1C20DB /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				3B4392A12AC88292D35C810B /* Pods-TpstreamsExample.debug.xcconfig */,
-				5709B34CF0A7D63546082F79 /* Pods-TpstreamsExample.release.xcconfig */,
+				D2798F5D93B5E992C1FB7148 /* Pods-TpstreamsExample.debug.xcconfig */,
+				E5FD7A2F929E72A9B0CE9DD8 /* Pods-TpstreamsExample.release.xcconfig */,
 			);
 			path = Pods;
 			sourceTree = "<group>";
@@ -105,13 +105,13 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 13B07F931A680F5B00A75B9A /* Build configuration list for PBXNativeTarget "TpstreamsExample" */;
 			buildPhases = (
-				C38B50BA6285516D6DCD4F65 /* [CP] Check Pods Manifest.lock */,
+				A44C5397CF197A724C9C1BA4 /* [CP] Check Pods Manifest.lock */,
 				13B07F871A680F5B00A75B9A /* Sources */,
 				13B07F8C1A680F5B00A75B9A /* Frameworks */,
 				13B07F8E1A680F5B00A75B9A /* Resources */,
 				00DD1BFF1BD5951E006B06BC /* Bundle React Native code and images */,
-				00EEFC60759A1932668264C0 /* [CP] Embed Pods Frameworks */,
-				E235C05ADACE081382539298 /* [CP] Copy Pods Resources */,
+				32D4AE2AD093297322681612 /* [CP] Embed Pods Frameworks */,
+				BDB7037011FA4DE37E62378B /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -183,7 +183,7 @@
 			shellPath = /bin/sh;
 			shellScript = "set -e\n\nWITH_ENVIRONMENT=\"$REACT_NATIVE_PATH/scripts/xcode/with-environment.sh\"\nREACT_NATIVE_XCODE=\"$REACT_NATIVE_PATH/scripts/react-native-xcode.sh\"\n\n/bin/sh -c \"$WITH_ENVIRONMENT $REACT_NATIVE_XCODE\"\n";
 		};
-		00EEFC60759A1932668264C0 /* [CP] Embed Pods Frameworks */ = {
+		32D4AE2AD093297322681612 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -200,7 +200,7 @@
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-TpstreamsExample/Pods-TpstreamsExample-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		C38B50BA6285516D6DCD4F65 /* [CP] Check Pods Manifest.lock */ = {
+		A44C5397CF197A724C9C1BA4 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -222,7 +222,7 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		E235C05ADACE081382539298 /* [CP] Copy Pods Resources */ = {
+		BDB7037011FA4DE37E62378B /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -255,11 +255,12 @@
 /* Begin XCBuildConfiguration section */
 		13B07F941A680F5B00A75B9A /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 3B4392A12AC88292D35C810B /* Pods-TpstreamsExample.debug.xcconfig */;
+			baseConfigurationReference = D2798F5D93B5E992C1FB7148 /* Pods-TpstreamsExample.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = BHAB7LC35Y;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = TpstreamsExample/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.1;
@@ -283,11 +284,12 @@
 		};
 		13B07F951A680F5B00A75B9A /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 5709B34CF0A7D63546082F79 /* Pods-TpstreamsExample.release.xcconfig */;
+			baseConfigurationReference = E5FD7A2F929E72A9B0CE9DD8 /* Pods-TpstreamsExample.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = BHAB7LC35Y;
 				INFOPLIST_FILE = TpstreamsExample/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.1;
 				LD_RUNPATH_SEARCH_PATHS = (

--- a/ios/TPStreamsPlayerHostingView.swift
+++ b/ios/TPStreamsPlayerHostingView.swift
@@ -1,0 +1,67 @@
+import SwiftUI
+import UIKit
+import AVKit
+
+@objcMembers
+public class TPStreamsPlayerHostingView: UIView {
+    private var hostingController: UIHostingController<AnyView>?
+    private var currentSourceUrl: String = "https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4"
+    
+    public override init(frame: CGRect) {
+        super.init(frame: frame)
+        setup()
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        setup()
+    }
+    
+    public override func layoutSubviews() {
+        super.layoutSubviews()
+        updateVideoView()
+    }
+    
+    private func setup() {
+        let controller = UIHostingController(rootView: AnyView(VideoPlayerView(videoURL: URL(string: currentSourceUrl)!, frame: frame)))
+        controller.view.backgroundColor = UIColor.clear
+        hostingController = controller
+
+        addSubview(controller.view)
+        controller.view.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+        controller.view.topAnchor.constraint(equalTo: topAnchor),
+        controller.view.bottomAnchor.constraint(equalTo: bottomAnchor),
+        controller.view.leadingAnchor.constraint(equalTo: leadingAnchor),
+        controller.view.trailingAnchor.constraint(equalTo: trailingAnchor),
+        ])
+    }
+    
+    private func updateVideoView() {
+        guard bounds.width > 0 && bounds.height > 0 else { return }
+        
+        if let videoURL = URL(string: currentSourceUrl) {
+            hostingController?.rootView = AnyView(VideoPlayerView(videoURL: videoURL, frame: bounds))
+        }
+    }
+
+    public func setSourceUrl(_ url: String) {
+        currentSourceUrl = url
+        updateVideoView()
+    }
+}
+
+private struct VideoPlayerView: View {
+  let videoURL: URL
+  let frame: CGRect
+  
+  var body: some View {
+    VideoPlayer(player: AVPlayer(url: videoURL))
+      .frame(width: frame.width, height: frame.height)
+      .clipped()
+      .contentShape(Rectangle())
+      .onAppear {
+        AVPlayer(url: videoURL).play()
+      }
+  }
+}

--- a/ios/TPStreamsRNPlayerView.mm
+++ b/ios/TPStreamsRNPlayerView.mm
@@ -6,6 +6,7 @@
 #import <react/renderer/components/TPStreamsSpec/RCTComponentViewHelpers.h>
 
 #import "RCTFabricComponentsPlugins.h"
+#import "TPStreams-Swift.h"
 
 using namespace facebook::react;
 
@@ -13,7 +14,7 @@ using namespace facebook::react;
 @end
 
 @implementation TPStreamsRNPlayerView {
-    UIView * _view;
+    TPStreamsPlayerHostingView * _view;
 }
 
 + (ComponentDescriptorProvider)componentDescriptorProvider
@@ -27,11 +28,17 @@ using namespace facebook::react;
     static const auto defaultProps = std::make_shared<const TPStreamsRNPlayerViewProps>();
     _props = defaultProps;
 
-    _view = [[UIView alloc] init];
+    _view = [[TPStreamsPlayerHostingView alloc] initWithFrame:frame];
     self.contentView = _view;
   }
 
   return self;
+}
+
+- (void)layoutSubviews
+{
+    [super layoutSubviews];
+    _view.frame = self.bounds;
 }
 
 - (void)updateProps:(Props::Shared const &)props oldProps:(Props::Shared const &)oldProps


### PR DESCRIPTION
- Replace UIView-based player with SwiftUI VideoPlayer implementation
- Add TPStreamsPlayerHostingView.swift with AVKit VideoPlayer integration
- Rename package from TPStreamsRNPlayerView to TPStreams
- Remove static_framework requirement from podspec
- Update native bridge to use new SwiftUI hosting view
- Add proper layout management and video URL handling
- Update example project with new pod configuration