### PR TITLE
fix(ios): initialize TPStreamsSDK on main queue to avoid threading issues

### DIFF
--- a/ios/TPStreamsModule.swift
+++ b/ios/TPStreamsModule.swift
@@ -10,13 +10,15 @@ class TPStreamsModule: NSObject {
    @objc func initialize(_ organizationId: NSString) {
      if !isInitialized {
        print("Initializing TPStreamsSDK with org code: \(organizationId)")
-       TPStreamsSDK.initialize(withOrgCode: organizationId as String)
+       DispatchQueue.main.async {
+        TPStreamsSDK.initialize(withOrgCode: organizationId as String)
+       }
        isInitialized = true
      }
    }
 
    @objc
    static func requiresMainQueueSetup() -> Bool {
-     return false
+     return true
    }
 }

--- a/ios/TPStreamsModule.swift
+++ b/ios/TPStreamsModule.swift
@@ -12,8 +12,8 @@ class TPStreamsModule: NSObject {
        print("Initializing TPStreamsSDK with org code: \(organizationId)")
        DispatchQueue.main.async {
         TPStreamsSDK.initialize(withOrgCode: organizationId as String)
+        self.isInitialized = true
        }
-       isInitialized = true
      }
    }
 


### PR DESCRIPTION
- The TPStreams SDK was previously being initialized on a background thread, which caused threading conflicts and unexpected crashes in Realm and download-related flows. 
- This change ensures the SDK is always initialized on the main queue, aligning with iOS requirements and preventing concurrency issues