### PR TITLE
feat(ios): add download management features to TPStreamsDownloadModule

### DIFF
--- a/ios/TPStreamsDownloadModule.mm
+++ b/ios/TPStreamsDownloadModule.mm
@@ -1,7 +1,48 @@
 #import <React/RCTBridgeModule.h>
+#import <React/RCTEventEmitter.h>
 
-@interface RCT_EXTERN_MODULE(TPStreamsDownload, NSObject)
+@interface RCT_EXTERN_MODULE(TPStreamsDownload, RCTEventEmitter)
 
-// Add download-related methods here if needed
+// Download Progress Listener Methods
+RCT_EXTERN_METHOD(addDownloadProgressListener:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+
+RCT_EXTERN_METHOD(removeDownloadProgressListener:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+
+// Download Control Methods
+RCT_EXTERN_METHOD(pauseDownload:(NSString *)videoId
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+
+RCT_EXTERN_METHOD(resumeDownload:(NSString *)videoId
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+
+RCT_EXTERN_METHOD(removeDownload:(NSString *)videoId
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+
+// Download Status Methods
+RCT_EXTERN_METHOD(isDownloaded:(NSString *)videoId
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+
+RCT_EXTERN_METHOD(isDownloading:(NSString *)videoId
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+
+RCT_EXTERN_METHOD(isPaused:(NSString *)videoId
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+
+RCT_EXTERN_METHOD(getDownloadStatus:(NSString *)videoId
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+
+RCT_EXTERN_METHOD(getAllDownloads:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+
+RCT_EXTERN_METHOD(supportedEvents)
 
 @end 

--- a/ios/TPStreamsDownloadModule.swift
+++ b/ios/TPStreamsDownloadModule.swift
@@ -1,13 +1,271 @@
 import Foundation
 import React
+import TPStreamsSDK
+
+private enum PlayerConstants {
+    static let statusNotDownloaded = "NotDownloaded"
+    static let statusDownloading = "Downloading"
+    static let statusPaused = "Paused"
+    static let statusCompleted = "Completed"
+    static let statusFailed = "Failed"
+    static let statusUnknown = "Unknown"
+}
 
 @objc(TPStreamsDownload)
-class TPStreamsDownloadModule: NSObject {
+class TPStreamsDownloadModule: RCTEventEmitter, TPStreamsDownloadDelegate {
     
-    @objc
-    static func requiresMainQueueSetup() -> Bool {
-        return false
+    private let downloadManager = TPStreamsDownloadManager.shared
+    private var isListening = false
+    
+    override init() {
+        super.init()
+        downloadManager.setTPStreamsDownloadDelegate(tpStreamsDownloadDelegate: self)
     }
     
-    // Download functionality will be implemented in future commits
-} 
+    @objc
+    override static func requiresMainQueueSetup() -> Bool {
+        return true
+    }
+    
+    @objc
+    func addDownloadProgressListener(_ resolve: @escaping RCTPromiseResolveBlock, rejecter reject: @escaping RCTPromiseRejectBlock) {
+        isListening = true
+        resolve(nil)
+    }
+    
+    @objc
+    func removeDownloadProgressListener(_ resolve: @escaping RCTPromiseResolveBlock, rejecter reject: @escaping RCTPromiseRejectBlock) {
+        isListening = false
+        resolve(nil)
+    }
+    
+    func onProgressChange(assetId: String, percentage: Double) {
+        if isListening {
+            notifyDownloadsChange()
+        }
+    }
+    
+    func onStateChange(status: Status, offlineAsset: OfflineAsset) {
+        if isListening {
+            notifyDownloadsChange()
+        }
+    }
+    
+    func onDelete(assetId: String) {
+        if isListening {
+            notifyDownloadsChange()
+        }
+    }
+    
+    func onStart(offlineAsset: OfflineAsset) {
+        if isListening {
+            notifyDownloadsChange()
+        }
+    }
+    
+    func onComplete(offlineAsset: OfflineAsset) {
+        if isListening {
+            notifyDownloadsChange()
+        }
+    }
+    
+    func onPause(offlineAsset: OfflineAsset) {
+        if isListening {
+            notifyDownloadsChange()
+        }
+    }
+    
+    func onResume(offlineAsset: OfflineAsset) {
+        if isListening {
+            notifyDownloadsChange()
+        }
+    }
+    
+    func onCanceled(assetId: String) {
+        if isListening {
+            notifyDownloadsChange()
+        }
+    }
+    
+    private func notifyDownloadsChange() {
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self else { return }
+            let downloadAssets = self.getAllDownloadItems()
+            self.sendEvent(withName: "onDownloadProgressChanged", body: downloadAssets)
+        }
+    }
+    
+    private func getAllDownloadItems() -> [[String: Any]] {
+        let offlineAssets = downloadManager.getAllOfflineAssets()
+        return offlineAssets.map { mapOfflineAssetToDict($0) }
+    }
+    
+    private func mapOfflineAssetToDict(_ asset: OfflineAsset) -> [String: Any] {
+        var item: [String: Any] = [:]
+        item["videoId"] = asset.assetId
+        item["title"] = asset.title
+        item["totalBytes"] = asset.size
+        item["downloadedBytes"] = calculateDownloadedBytes(size: asset.size, progress: asset.percentageCompleted)
+        item["progressPercentage"] = asset.percentageCompleted
+        item["state"] = mapDownloadStatus(Status(rawValue: asset.status))
+        item["metadata"] = "{}"
+        
+        return item
+    }
+
+    private func calculateDownloadedBytes(size: Any?, progress: Any?) -> Int64 {
+        guard let totalBytes = size as? Double,
+            let progressPercentage = progress as? Double else {
+            return 0
+        }
+        return Int64((progressPercentage / 100.0) * totalBytes)
+    }
+    
+    @objc
+    func pauseDownload(_ videoId: String, resolver resolve: @escaping RCTPromiseResolveBlock, rejecter reject: @escaping RCTPromiseRejectBlock) {
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self else {
+                reject("ERROR", "Module deallocated", nil)
+                return
+            }
+            print("pauseDownload called for videoId: \(videoId)")
+            self.downloadManager.pauseDownload(videoId)
+            resolve(nil)
+        }
+    }
+    
+    @objc
+    func resumeDownload(_ videoId: String, resolver resolve: @escaping RCTPromiseResolveBlock, rejecter reject: @escaping RCTPromiseRejectBlock) {
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self else {
+                reject("ERROR", "Module deallocated", nil)
+                return
+            }
+            self.downloadManager.resumeDownload(videoId)
+            resolve(nil)
+        }
+    }
+    
+    @objc
+    func removeDownload(_ videoId: String, resolver resolve: @escaping RCTPromiseResolveBlock, rejecter reject: @escaping RCTPromiseRejectBlock) {
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self else {
+                reject("ERROR", "Module deallocated", nil)
+                return
+            }
+            self.downloadManager.deleteDownload(videoId)
+            print("removeDownload called for videoId: \(videoId)")
+            resolve(nil)
+        }
+    }
+    
+    @objc
+    func isDownloaded(_ videoId: String, resolver resolve: @escaping RCTPromiseResolveBlock, rejecter reject: @escaping RCTPromiseRejectBlock) {
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self else {
+                reject("ERROR", "Module deallocated", nil)
+                return
+            }
+            let offlineAssets = self.downloadManager.getAllOfflineAssets()
+            let isDownloaded = offlineAssets.contains { asset in
+                asset.assetId == videoId && Status(rawValue: asset.status) == .finished
+            }
+            resolve(isDownloaded)
+        }
+    }
+    
+    @objc
+    func isDownloading(_ videoId: String, resolver resolve: @escaping RCTPromiseResolveBlock, rejecter reject: @escaping RCTPromiseRejectBlock) {
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self else {
+                reject("ERROR", "Module deallocated", nil)
+                return
+            }
+            let offlineAssets = self.downloadManager.getAllOfflineAssets()
+            let isDownloading = offlineAssets.contains { asset in
+                asset.assetId == videoId && Status(rawValue: asset.status) == .inProgress
+            }
+            resolve(isDownloading)
+        }
+    }
+    
+    @objc
+    func isPaused(_ videoId: String, resolver resolve: @escaping RCTPromiseResolveBlock, rejecter reject: @escaping RCTPromiseRejectBlock) {
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self else {
+                reject("ERROR", "Module deallocated", nil)
+                return
+            }
+            let offlineAssets = self.downloadManager.getAllOfflineAssets()
+            let isPaused = offlineAssets.contains { asset in
+                asset.assetId == videoId && Status(rawValue: asset.status) == .paused
+            }
+            resolve(isPaused)
+        }
+    }
+    
+    @objc
+    func getDownloadStatus(_ videoId: String, resolver resolve: @escaping RCTPromiseResolveBlock, rejecter reject: @escaping RCTPromiseRejectBlock) {
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self else {
+                reject("ERROR", "Module deallocated", nil)
+                return
+            }
+            let offlineAssets = self.downloadManager.getAllOfflineAssets()
+            
+            if let asset = offlineAssets.first(where: { $0.assetId == videoId }) {
+                resolve(mapDownloadStatus(Status(rawValue: asset.status)))
+            } else {
+                resolve("NotDownloaded")
+            }
+        }
+    }
+    
+    @objc
+    func getAllDownloads(_ resolve: @escaping RCTPromiseResolveBlock, rejecter reject: @escaping RCTPromiseRejectBlock) {
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self else {
+                reject("ERROR", "Module deallocated", nil)
+                return
+            }
+            let downloadItems = self.getAllDownloadItems()
+            resolve(downloadItems)
+        }
+    }
+
+    private func mapDownloadStatus(_ status: Status?) -> String {
+        guard let status = status else { return PlayerConstants.statusUnknown }
+        
+        switch status {
+        case .inProgress:
+            return PlayerConstants.statusDownloading
+        case .paused:
+            return PlayerConstants.statusPaused
+        case .finished:
+            return PlayerConstants.statusCompleted
+        case .failed:
+            return PlayerConstants.statusFailed
+        default:
+            return PlayerConstants.statusNotDownloaded
+        }
+    }
+
+    @objc
+    override func supportedEvents() -> [String] {
+        return ["onDownloadProgressChanged"]
+    }
+    
+    @objc
+    override func addListener(_ eventName: String) {
+        super.addListener(eventName)
+    }
+    
+    @objc
+    override func removeListeners(_ count: Double) {
+        super.removeListeners(count)
+        
+        if count >= 1 && isListening {
+            isListening = false
+        }
+    }
+}

--- a/ios/TPStreamsDownloadModule.swift
+++ b/ios/TPStreamsDownloadModule.swift
@@ -128,7 +128,6 @@ class TPStreamsDownloadModule: RCTEventEmitter, TPStreamsDownloadDelegate {
                 reject("ERROR", "Module deallocated", nil)
                 return
             }
-            print("pauseDownload called for videoId: \(videoId)")
             self.downloadManager.pauseDownload(videoId)
             resolve(nil)
         }
@@ -154,7 +153,6 @@ class TPStreamsDownloadModule: RCTEventEmitter, TPStreamsDownloadDelegate {
                 return
             }
             self.downloadManager.deleteDownload(videoId)
-            print("removeDownload called for videoId: \(videoId)")
             resolve(nil)
         }
     }

--- a/ios/TPStreamsDownloadModule.swift
+++ b/ios/TPStreamsDownloadModule.swift
@@ -162,15 +162,7 @@ class TPStreamsDownloadModule: RCTEventEmitter, TPStreamsDownloadDelegate {
     @objc
     func isDownloaded(_ videoId: String, resolver resolve: @escaping RCTPromiseResolveBlock, rejecter reject: @escaping RCTPromiseRejectBlock) {
         DispatchQueue.main.async { [weak self] in
-            guard let self = self else {
-                reject("ERROR", "Module deallocated", nil)
-                return
-            }
-            let offlineAssets = self.downloadManager.getAllOfflineAssets()
-            let isDownloaded = offlineAssets.contains { asset in
-                asset.assetId == videoId && Status(rawValue: asset.status) == .finished
-            }
-            resolve(isDownloaded)
+            resolve(self?.downloadManager.isAssetDownloaded(assetID: videoId) ?? false)
         }
     }
     
@@ -216,7 +208,7 @@ class TPStreamsDownloadModule: RCTEventEmitter, TPStreamsDownloadDelegate {
             if let asset = offlineAssets.first(where: { $0.assetId == videoId }) {
                 resolve(mapDownloadStatus(Status(rawValue: asset.status)))
             } else {
-                resolve("NotDownloaded")
+                resolve(PlayerConstants.statusNotDownloaded)
             }
         }
     }


### PR DESCRIPTION
- Refactored TPStreamsDownloadModule to inherit from RCTEventEmitter for event handling.
- Added methods for managing download progress listeners (add/remove).
- Implemented download control methods: pause, resume, and remove downloads.
- Introduced status-checking methods: isDownloaded, isDownloading, isPaused, and getDownloadStatus.
- Added method to retrieve all downloads and notify listeners of progress changes.
- Defined constants for download status to improve readability and maintainability.