### PR TITLE
fix(ios): download removal of in-progress assets

### DIFF
--- a/ios/TPStreamsDownloadModule.swift
+++ b/ios/TPStreamsDownloadModule.swift
@@ -154,7 +154,7 @@ class TPStreamsDownloadModule: RCTEventEmitter, TPStreamsDownloadDelegate {
             }
             if self.downloadManager.isAssetDownloaded(assetID: videoId) {
                 self.downloadManager.deleteDownload(videoId)
-            }else{
+            } else {
                 self.downloadManager.cancelDownload(videoId)
             }
             resolve(nil)

--- a/ios/TPStreamsDownloadModule.swift
+++ b/ios/TPStreamsDownloadModule.swift
@@ -152,7 +152,11 @@ class TPStreamsDownloadModule: RCTEventEmitter, TPStreamsDownloadDelegate {
                 reject("ERROR", "Module deallocated", nil)
                 return
             }
-            self.downloadManager.deleteDownload(videoId)
+            if self.downloadManager.isAssetDownloaded(assetID: videoId) {
+                self.downloadManager.deleteDownload(videoId)
+            }else{
+                self.downloadManager.cancelDownload(videoId)
+            }
             resolve(nil)
         }
     }


### PR DESCRIPTION
- Previously, removing a download that was still in progress failed because the iOS SDK uses separate APIs for active vs completed downloads. 
- This update adds checks to ensure the correct API is called based on the download state.