### PR TITLE
fix(ios): add support for metadata and thumbnail in download item

### DIFF
--- a/TPStreamsRNPlayerView.podspec
+++ b/TPStreamsRNPlayerView.podspec
@@ -21,7 +21,7 @@ Pod::Spec.new do |s|
       'DEFINES_MODULE' => 'YES',
       'CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES' => 'YES'
     }
-  s.dependency "TPStreamsSDK"
+  s.dependency "TPStreamsSDK" , "1.2.7"
 
   
   # Ensure the module is not built as a framework to avoid bridging header conflicts

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1666,7 +1666,7 @@ PODS:
     - Sentry/Core (= 8.50.2)
   - Sentry/Core (8.50.2)
   - SocketRocket (0.7.1)
-  - TPStreamsRNPlayerView (0.2.19):
+  - TPStreamsRNPlayerView (1.0.0):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1689,9 +1689,9 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - TPStreamsSDK
+    - TPStreamsSDK (= 1.2.7)
     - Yoga
-  - TPStreamsSDK (1.2.6):
+  - TPStreamsSDK (1.2.7):
     - Alamofire (~> 5.9.0)
     - M3U8Kit (~> 1.1.0)
     - ReachabilitySwift (~> 5.2.2)
@@ -2007,8 +2007,8 @@ SPEC CHECKSUMS:
   RealmSwift: 7c258367cc498594aa989b7d9620989a276ad7f4
   Sentry: d95f5f3b32d01324b3e27d3c52747005302cc026
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
-  TPStreamsRNPlayerView: 3b8fa6213860dab88ef724aa170fbe29522e1b96
-  TPStreamsSDK: 941499388576b2b6b2cf2f96aea259f410e2a410
+  TPStreamsRNPlayerView: 17f98aaa841175e62e1ad5efb67c4d60fb936e7a
+  TPStreamsSDK: ad08c81f3e523ef6aa465d864e2714c0a5d582f9
   Yoga: 50518ade05048235d91a78b803336dbb5b159d5d
 
 PODFILE CHECKSUM: 3f7e2acbe0418b2ae4e9fbd9102ff83a37c15215

--- a/example/ios/TpstreamsExample.xcodeproj/project.pbxproj
+++ b/example/ios/TpstreamsExample.xcodeproj/project.pbxproj
@@ -9,22 +9,22 @@
 /* Begin PBXBuildFile section */
 		13B07FBF1A68108700A75B9A /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB51A68108700A75B9A /* Images.xcassets */; };
 		761780ED2CA45674006654EE /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 761780EC2CA45674006654EE /* AppDelegate.swift */; };
+		80AB41FAD9B0857839664760 /* Pods_TpstreamsExample.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A00624465975E511A43A12DF /* Pods_TpstreamsExample.framework */; };
 		81AB9BB82411601600AC10FF /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */; };
 		91AD30DC239874A835137420 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB81A68108700A75B9A /* PrivacyInfo.xcprivacy */; };
-		99F5621A2BCE0C4C1449CCF7 /* Pods_TpstreamsExample.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 864B813AC5D12CEB99CAC4F9 /* Pods_TpstreamsExample.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
-		06F21157D7D6685060D8EFEF /* Pods-TpstreamsExample.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TpstreamsExample.release.xcconfig"; path = "Target Support Files/Pods-TpstreamsExample/Pods-TpstreamsExample.release.xcconfig"; sourceTree = "<group>"; };
 		13B07F961A680F5B00A75B9A /* TpstreamsExample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = TpstreamsExample.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		13B07FB51A68108700A75B9A /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = TpstreamsExample/Images.xcassets; sourceTree = "<group>"; };
 		13B07FB61A68108700A75B9A /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = TpstreamsExample/Info.plist; sourceTree = "<group>"; };
 		13B07FB81A68108700A75B9A /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = PrivacyInfo.xcprivacy; path = TpstreamsExample/PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
-		2EF48DE6371FFAA641A86B41 /* Pods-TpstreamsExample.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TpstreamsExample.debug.xcconfig"; path = "Target Support Files/Pods-TpstreamsExample/Pods-TpstreamsExample.debug.xcconfig"; sourceTree = "<group>"; };
 		761780EC2CA45674006654EE /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AppDelegate.swift; path = TpstreamsExample/AppDelegate.swift; sourceTree = "<group>"; };
 		81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = LaunchScreen.storyboard; path = TpstreamsExample/LaunchScreen.storyboard; sourceTree = "<group>"; };
-		864B813AC5D12CEB99CAC4F9 /* Pods_TpstreamsExample.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_TpstreamsExample.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		A00624465975E511A43A12DF /* Pods_TpstreamsExample.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_TpstreamsExample.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		BB8F9CBA95460500523B8102 /* Pods-TpstreamsExample.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TpstreamsExample.debug.xcconfig"; path = "Target Support Files/Pods-TpstreamsExample/Pods-TpstreamsExample.debug.xcconfig"; sourceTree = "<group>"; };
 		ED297162215061F000B7C4FE /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
+		F0BD6CD73A9B516162CB4F56 /* Pods-TpstreamsExample.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TpstreamsExample.release.xcconfig"; path = "Target Support Files/Pods-TpstreamsExample/Pods-TpstreamsExample.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -32,7 +32,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				99F5621A2BCE0C4C1449CCF7 /* Pods_TpstreamsExample.framework in Frameworks */,
+				80AB41FAD9B0857839664760 /* Pods_TpstreamsExample.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -55,7 +55,7 @@
 			isa = PBXGroup;
 			children = (
 				ED297162215061F000B7C4FE /* JavaScriptCore.framework */,
-				864B813AC5D12CEB99CAC4F9 /* Pods_TpstreamsExample.framework */,
+				A00624465975E511A43A12DF /* Pods_TpstreamsExample.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -92,8 +92,8 @@
 		BBD78D7AC51CEA395F1C20DB /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				2EF48DE6371FFAA641A86B41 /* Pods-TpstreamsExample.debug.xcconfig */,
-				06F21157D7D6685060D8EFEF /* Pods-TpstreamsExample.release.xcconfig */,
+				BB8F9CBA95460500523B8102 /* Pods-TpstreamsExample.debug.xcconfig */,
+				F0BD6CD73A9B516162CB4F56 /* Pods-TpstreamsExample.release.xcconfig */,
 			);
 			path = Pods;
 			sourceTree = "<group>";
@@ -105,13 +105,13 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 13B07F931A680F5B00A75B9A /* Build configuration list for PBXNativeTarget "TpstreamsExample" */;
 			buildPhases = (
-				A19F53EFDD506E0235373B74 /* [CP] Check Pods Manifest.lock */,
+				EEF7E5856510CB2080F37EE0 /* [CP] Check Pods Manifest.lock */,
 				13B07F871A680F5B00A75B9A /* Sources */,
 				13B07F8C1A680F5B00A75B9A /* Frameworks */,
 				13B07F8E1A680F5B00A75B9A /* Resources */,
 				00DD1BFF1BD5951E006B06BC /* Bundle React Native code and images */,
-				B98D1E4BD99A22E5CA7C3BF8 /* [CP] Embed Pods Frameworks */,
-				75CF0B505AE3693E9509FB15 /* [CP] Copy Pods Resources */,
+				0B42D2A2FA25DACDE3CC7E34 /* [CP] Embed Pods Frameworks */,
+				2ACDAE03569BCC0D21992103 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -183,7 +183,24 @@
 			shellPath = /bin/sh;
 			shellScript = "set -e\n\nWITH_ENVIRONMENT=\"$REACT_NATIVE_PATH/scripts/xcode/with-environment.sh\"\nREACT_NATIVE_XCODE=\"$REACT_NATIVE_PATH/scripts/react-native-xcode.sh\"\n\n/bin/sh -c \"$WITH_ENVIRONMENT $REACT_NATIVE_XCODE\"\n";
 		};
-		75CF0B505AE3693E9509FB15 /* [CP] Copy Pods Resources */ = {
+		0B42D2A2FA25DACDE3CC7E34 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-TpstreamsExample/Pods-TpstreamsExample-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-TpstreamsExample/Pods-TpstreamsExample-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-TpstreamsExample/Pods-TpstreamsExample-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		2ACDAE03569BCC0D21992103 /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -200,7 +217,7 @@
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-TpstreamsExample/Pods-TpstreamsExample-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		A19F53EFDD506E0235373B74 /* [CP] Check Pods Manifest.lock */ = {
+		EEF7E5856510CB2080F37EE0 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -222,23 +239,6 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		B98D1E4BD99A22E5CA7C3BF8 /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-TpstreamsExample/Pods-TpstreamsExample-frameworks-${CONFIGURATION}-input-files.xcfilelist",
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-TpstreamsExample/Pods-TpstreamsExample-frameworks-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-TpstreamsExample/Pods-TpstreamsExample-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
@@ -255,7 +255,7 @@
 /* Begin XCBuildConfiguration section */
 		13B07F941A680F5B00A75B9A /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 2EF48DE6371FFAA641A86B41 /* Pods-TpstreamsExample.debug.xcconfig */;
+			baseConfigurationReference = BB8F9CBA95460500523B8102 /* Pods-TpstreamsExample.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
@@ -283,7 +283,7 @@
 		};
 		13B07F951A680F5B00A75B9A /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 06F21157D7D6685060D8EFEF /* Pods-TpstreamsExample.release.xcconfig */;
+			baseConfigurationReference = F0BD6CD73A9B516162CB4F56 /* Pods-TpstreamsExample.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;

--- a/ios/TPStreamsDownloadModule.swift
+++ b/ios/TPStreamsDownloadModule.swift
@@ -109,7 +109,7 @@ class TPStreamsDownloadModule: RCTEventEmitter, TPStreamsDownloadDelegate {
         item["downloadedBytes"] = calculateDownloadedBytes(size: asset.size, progress: asset.percentageCompleted)
         item["progressPercentage"] = asset.percentageCompleted
         item["state"] = mapDownloadStatus(Status(rawValue: asset.status))
-        item["metadata"] = asset.metadata
+        item["metadata"] = asset.metadata ?? "{}"
         
         return item
     }

--- a/ios/TPStreamsDownloadModule.swift
+++ b/ios/TPStreamsDownloadModule.swift
@@ -104,11 +104,12 @@ class TPStreamsDownloadModule: RCTEventEmitter, TPStreamsDownloadDelegate {
         var item: [String: Any] = [:]
         item["videoId"] = asset.assetId
         item["title"] = asset.title
+        item["thumbnailUrl"] = asset.thumbnailURL
         item["totalBytes"] = asset.size
         item["downloadedBytes"] = calculateDownloadedBytes(size: asset.size, progress: asset.percentageCompleted)
         item["progressPercentage"] = asset.percentageCompleted
         item["state"] = mapDownloadStatus(Status(rawValue: asset.status))
-        item["metadata"] = "{}"
+        item["metadata"] = asset.metadata
         
         return item
     }

--- a/ios/TPStreamsRNPlayerView.swift
+++ b/ios/TPStreamsRNPlayerView.swift
@@ -131,11 +131,13 @@ class TPStreamsRNPlayerView: UIView {
     }
     
     private func createPlayerConfigBuilder() -> TPStreamPlayerConfigurationBuilder {
+        let metadataDict = parseMetadataJSON(from: downloadMetadata)
         let configBuilder = TPStreamPlayerConfigurationBuilder()
             .setPreferredForwardDuration(15)
             .setPreferredRewindDuration(5)
             .setprogressBarThumbColor(.systemBlue)
             .setwatchedProgressTrackColor(.systemBlue)
+            .setDownloadMetadata(metadataDict)
         
         if enableDownload {
             configBuilder.showDownloadOption()
@@ -169,6 +171,21 @@ class TPStreamsRNPlayerView: UIView {
             self.playerStatusObserver?.invalidate()
             self.playerStatusObserver = nil
         }
+    }
+
+    private func parseMetadataJSON(from jsonString: NSString?) -> [String: String]? {
+        guard let metadataString = jsonString as String? else { return nil }
+        
+        print("Metadata string: \(metadataString)")
+        guard let data = metadataString.data(using: .utf8) else { return nil }
+        do {
+            if let json = try JSONSerialization.jsonObject(with: data, options: []) as? [String: String] {
+                return json
+            }
+        } catch {
+            print("Error parsing metadata JSON: \(error)")
+        }
+        return nil
     }
     
     @objc func seekTo(position: Double) {

--- a/ios/TPStreamsRNPlayerView.swift
+++ b/ios/TPStreamsRNPlayerView.swift
@@ -176,7 +176,6 @@ class TPStreamsRNPlayerView: UIView {
     private func parseMetadataJSON(from jsonString: NSString?) -> [String: String]? {
         guard let metadataString = jsonString as String? else { return nil }
         
-        print("Metadata string: \(metadataString)")
         guard let data = metadataString.data(using: .utf8) else { return nil }
         do {
             if let json = try JSONSerialization.jsonObject(with: data, options: []) as? [String: String] {


### PR DESCRIPTION
- Enable downloadItem to include thumbnails and custom metadata to provide users with better visual identification and additional context about downloaded content. 
- This allows the app to display meaningful information about offline videos and improve the overall download management experience.