### PR TITLE
feat: Add download state change events and improve status handling

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -3,4 +3,4 @@ Tpstreams_minSdkVersion=24
 Tpstreams_targetSdkVersion=34
 Tpstreams_compileSdkVersion=35
 Tpstreams_ndkVersion=27.1.12297006
-Tpstreams_tpstreamsAndroidPlayerVersion=1.0.16
+Tpstreams_tpstreamsAndroidPlayerVersion=1.0.17

--- a/ios/TPStreamsDownloadModule.swift
+++ b/ios/TPStreamsDownloadModule.swift
@@ -60,9 +60,6 @@ class TPStreamsDownloadModule: RCTEventEmitter, TPStreamsDownloadDelegate {
     
     func onStateChange(status: Status, offlineAsset: OfflineAsset) {
         if isListening {
-            if let offlineAsset = getOfflineAsset(assetId: offlineAsset.assetId) {
-                notifyDownloadStateChanged(offlineAsset: offlineAsset)
-            }
             notifyDownloadsChange()
         }
     }
@@ -78,36 +75,28 @@ class TPStreamsDownloadModule: RCTEventEmitter, TPStreamsDownloadDelegate {
     
     func onStart(offlineAsset: OfflineAsset) {
         if isListening {
-            if let offlineAsset = getOfflineAsset(assetId: offlineAsset.assetId) {
-                notifyDownloadStateChanged(offlineAsset: offlineAsset)
-            }
+            notifyDownloadStateChanged(offlineAsset: offlineAsset)
             notifyDownloadsChange()
         }
     }
     
     func onComplete(offlineAsset: OfflineAsset) {
         if isListening {
-            if let offlineAsset = getOfflineAsset(assetId: offlineAsset.assetId) {
-                notifyDownloadStateChanged(offlineAsset: offlineAsset)
-            }
+            notifyDownloadStateChanged(offlineAsset: offlineAsset)
             notifyDownloadsChange()
         }
     }
     
     func onPause(offlineAsset: OfflineAsset) {
         if isListening {
-            if let offlineAsset = getOfflineAsset(assetId: offlineAsset.assetId) {
-                notifyDownloadStateChanged(offlineAsset: offlineAsset)
-            }
+            notifyDownloadStateChanged(offlineAsset: offlineAsset)
             notifyDownloadsChange()
         }
     }
     
     func onResume(offlineAsset: OfflineAsset) {
         if isListening {
-            if let offlineAsset = getOfflineAsset(assetId: offlineAsset.assetId) {
-                notifyDownloadStateChanged(offlineAsset: offlineAsset)
-            }
+            notifyDownloadStateChanged(offlineAsset: offlineAsset)
             notifyDownloadsChange()
         }
     }

--- a/ios/TPStreamsDownloadModule.swift
+++ b/ios/TPStreamsDownloadModule.swift
@@ -3,11 +3,13 @@ import React
 import TPStreamsSDK
 
 private enum PlayerConstants {
-    static let statusNotDownloaded = "NotDownloaded"
+    static let statusQueued = "Queued"
     static let statusDownloading = "Downloading"
     static let statusPaused = "Paused"
     static let statusCompleted = "Completed"
     static let statusFailed = "Failed"
+    static let statusRemoving = "Removing"
+    static let statusRestarting = "Restarting"
     static let statusUnknown = "Unknown"
 }
 
@@ -58,42 +60,63 @@ class TPStreamsDownloadModule: RCTEventEmitter, TPStreamsDownloadDelegate {
     
     func onStateChange(status: Status, offlineAsset: OfflineAsset) {
         if isListening {
+            if let offlineAsset = getOfflineAsset(assetId: offlineAsset.assetId) {
+                notifyDownloadStateChanged(offlineAsset: offlineAsset)
+            }
             notifyDownloadsChange()
         }
     }
     
     func onDelete(assetId: String) {
         if isListening {
+            if let offlineAsset = getOfflineAsset(assetId: assetId) {
+                notifyDownloadStateChanged(offlineAsset: offlineAsset)
+            }
             notifyDownloadsChange()
         }
     }
     
     func onStart(offlineAsset: OfflineAsset) {
         if isListening {
+            if let offlineAsset = getOfflineAsset(assetId: offlineAsset.assetId) {
+                notifyDownloadStateChanged(offlineAsset: offlineAsset)
+            }
             notifyDownloadsChange()
         }
     }
     
     func onComplete(offlineAsset: OfflineAsset) {
         if isListening {
+            if let offlineAsset = getOfflineAsset(assetId: offlineAsset.assetId) {
+                notifyDownloadStateChanged(offlineAsset: offlineAsset)
+            }
             notifyDownloadsChange()
         }
     }
     
     func onPause(offlineAsset: OfflineAsset) {
         if isListening {
+            if let offlineAsset = getOfflineAsset(assetId: offlineAsset.assetId) {
+                notifyDownloadStateChanged(offlineAsset: offlineAsset)
+            }
             notifyDownloadsChange()
         }
     }
     
     func onResume(offlineAsset: OfflineAsset) {
         if isListening {
+            if let offlineAsset = getOfflineAsset(assetId: offlineAsset.assetId) {
+                notifyDownloadStateChanged(offlineAsset: offlineAsset)
+            }
             notifyDownloadsChange()
         }
     }
     
     func onCanceled(assetId: String) {
         if isListening {
+            if let offlineAsset = getOfflineAsset(assetId: assetId) {
+                notifyDownloadStateChanged(offlineAsset: offlineAsset)
+            }
             notifyDownloadsChange()
         }
     }
@@ -111,6 +134,28 @@ class TPStreamsDownloadModule: RCTEventEmitter, TPStreamsDownloadDelegate {
             guard let self = self else { return }
             let downloadAssets = self.getAllDownloadItems()
             self.sendEvent(withName: "onDownloadProgressChanged", body: downloadAssets)
+        }
+    }
+    
+    private func notifyDownloadStateChanged(offlineAsset: OfflineAsset, error: Error? = nil) {
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self else { return }
+            
+            let downloadItem = self.mapOfflineAssetToDict(offlineAsset)
+            
+            var eventData: [String: Any] = [:]
+            eventData["downloadItem"] = downloadItem
+            
+            if let error = error {
+                eventData["error"] = [
+                    "message": error.localizedDescription,
+                    "type": String(describing: type(of: error))
+                ]
+            } else {
+                eventData["error"] = NSNull()
+            }
+            
+            self.sendEvent(withName: "onDownloadStateChanged", body: eventData)
         }
     }
     
@@ -230,7 +275,7 @@ class TPStreamsDownloadModule: RCTEventEmitter, TPStreamsDownloadDelegate {
             if let asset = offlineAssets.first(where: { $0.assetId == videoId }) {
                 resolve(mapDownloadStatus(Status(rawValue: asset.status)))
             } else {
-                resolve(PlayerConstants.statusNotDownloaded)
+                resolve(PlayerConstants.statusUnknown)
             }
         }
     }
@@ -260,13 +305,17 @@ class TPStreamsDownloadModule: RCTEventEmitter, TPStreamsDownloadDelegate {
         case .failed:
             return PlayerConstants.statusFailed
         default:
-            return PlayerConstants.statusNotDownloaded
+            return PlayerConstants.statusUnknown
         }
+    }
+
+    private func getOfflineAsset(assetId: String) -> OfflineAsset? {
+        return downloadManager.getAllOfflineAssets().first(where: { $0.assetId == assetId })
     }
 
     @objc
     override func supportedEvents() -> [String] {
-        return ["onDownloadProgressChanged"]
+        return ["onDownloadProgressChanged", "onDownloadStateChanged"]
     }
     
     @objc

--- a/src/TPStreamsDownload.tsx
+++ b/src/TPStreamsDownload.tsx
@@ -19,6 +19,16 @@ export type DownloadProgressListener = (
   downloads: DownloadProgressChange[]
 ) => void;
 
+export interface DownloadError {
+  message: string;
+  type: string;
+}
+
+export type DownloadStateChangeListener = (
+  downloadItem: DownloadItem,
+  error: DownloadError | null
+) => void;
+
 const downloadEventEmitter = new NativeEventEmitter(TPStreamsDownload);
 
 export function addDownloadProgressListener(): Promise<void> {
@@ -36,6 +46,14 @@ export function onDownloadProgressChanged(
     'onDownloadProgressChanged',
     listener
   );
+}
+
+export function onDownloadStateChanged(
+  listener: DownloadStateChangeListener
+): EmitterSubscription {
+  return downloadEventEmitter.addListener('onDownloadStateChanged', (event) => {
+    listener(event.downloadItem, event.error);
+  });
 }
 
 export function pauseDownload(videoId: string): Promise<void> {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -19,9 +19,11 @@ export {
   addDownloadProgressListener,
   removeDownloadProgressListener,
   onDownloadProgressChanged,
+  onDownloadStateChanged,
   type DownloadItem,
   type DownloadProgressChange,
   type DownloadProgressListener,
+  type DownloadStateChangeListener,
 } from './TPStreamsDownload';
 
 const TPStreamsModule = NativeModules.TPStreams;


### PR DESCRIPTION
- Bump `TpstreamsAndroidPlayer` version from 1.0.16 to 1.0.17
- Add `onDownloadStateChanged` callback in Android and iOS modules
- Extract `createDownloadItemMap` helper to reduce code duplication in Android
- Update iOS status constants (add Queued, Removing, Restarting states)
- Export new download state change functionality in public API