### PR TITLE
fix(ios): resolve RCTCallableJSModules error in download module initization

### DIFF
--- a/ios/TPStreamsDownloadModule.swift
+++ b/ios/TPStreamsDownloadModule.swift
@@ -23,12 +23,16 @@ class TPStreamsDownloadModule: RCTEventEmitter, TPStreamsDownloadDelegate {
     private let downloadManager = TPStreamsDownloadManager.shared
     private var isListening = false
     private var tokenDelegate: TokenRequestDelegate?
-    static var shared: TPStreamsDownloadModule?
-    
+    private static var _shared: TPStreamsDownloadModule?
+
+    static var shared: TPStreamsDownloadModule? {
+        return _shared
+    }
+
     override init() {
         super.init()
+        TPStreamsDownloadModule._shared = self
         downloadManager.setTPStreamsDownloadDelegate(tpStreamsDownloadDelegate: self)
-        TPStreamsDownloadModule.shared = self
     }
 
     func setAccessTokenDelegate(_ delegate: TokenRequestDelegate) {

--- a/ios/TPStreamsModule.swift
+++ b/ios/TPStreamsModule.swift
@@ -9,7 +9,6 @@ class TPStreamsModule: NSObject {
 
    @objc func initialize(_ organizationId: NSString) {
      if !isInitialized {
-       print("Initializing TPStreamsSDK with org code: \(organizationId)")
        DispatchQueue.main.async {
         TPStreamsSDK.initialize(withOrgCode: organizationId as String)
         self.isInitialized = true
@@ -19,7 +18,7 @@ class TPStreamsModule: NSObject {
    }
 
    private func initializeDownloadModule() {
-     let _ = TPStreamsDownloadModule()
+     _ = TPStreamsDownloadModule.shared
    }
 
    @objc


### PR DESCRIPTION
- Previously on React Native versions lower than 0.75, the app crashed with "RCTCallableJSModules is not set". This was caused by manually initializing `TPStreamsDownloadModule` outside the React Native bridge, which prevented
proper event emission to JavaScript.
- The fix ensures the module is initialized by the React Native bridge, allowing events to be emitted correctly.
