### PR TITLE
fix: allow flexible metadata types to support complex data structures

### DIFF
--- a/TPStreamsRNPlayerView.podspec
+++ b/TPStreamsRNPlayerView.podspec
@@ -21,7 +21,7 @@ Pod::Spec.new do |s|
       'DEFINES_MODULE' => 'YES',
       'CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES' => 'YES'
     }
-  s.dependency "TPStreamsSDK" , "1.2.8"
+  s.dependency "TPStreamsSDK" , "1.2.9"
 
   
   # Ensure the module is not built as a framework to avoid bridging header conflicts

--- a/android/src/main/java/com/tpstreams/JsonUtils.kt
+++ b/android/src/main/java/com/tpstreams/JsonUtils.kt
@@ -1,0 +1,46 @@
+package com.tpstreams
+
+import org.json.JSONObject
+
+object JsonUtils {
+    
+    fun parseJsonString(map: Map<String, Any>?): Map<String, Any> {
+        val result = mutableMapOf<String, Any>()
+        map?.forEach { (key, value) ->
+            when (value) {
+                is String -> {
+                    if (value.startsWith("{") && value.endsWith("}")) {
+                        try {
+                            val json = JSONObject(value)
+                            result[key] = jsonToMap(json)
+                        } catch (e: Exception) {
+                            result[key] = value
+                        }
+                    } else {
+                        result[key] = value
+                    }
+                }
+                else -> result[key] = value
+            }
+        }
+        return result
+    }
+
+    private fun jsonToMap(json: JSONObject): Map<String, Any> {
+        val map = mutableMapOf<String, Any>()
+        val keys = json.keys()
+        while (keys.hasNext()) {
+            val key = keys.next()
+            val value = json.get(key)
+            when (value) {
+                is String -> map[key] = value
+                is Int -> map[key] = value
+                is Double -> map[key] = value
+                is Boolean -> map[key] = value
+                is JSONObject -> map[key] = jsonToMap(value)
+                else -> map[key] = value.toString()
+            }
+        }
+        return map
+    }
+} 

--- a/android/src/main/java/com/tpstreams/TPStreamsDownloadModule.kt
+++ b/android/src/main/java/com/tpstreams/TPStreamsDownloadModule.kt
@@ -109,13 +109,8 @@ class TPStreamsDownloadModule(private val reactContext: ReactApplicationContext)
         map.putDouble("downloadedBytes", item.downloadedBytes.toDouble())
         map.putDouble("progressPercentage", item.progressPercentage.toDouble())
         map.putString("state", downloadClient.getDownloadStatus(item.assetId))
-        
-        val metadataJson = org.json.JSONObject()
-        item.metadata.forEach { (key, value) ->
-            metadataJson.put(key, value)
-        }
-        map.putString("metadata", metadataJson.toString())
-        
+        val parsedMetadata = JsonUtils.parseJsonString(item.metadata)
+        map.putMap("metadata", Arguments.makeNativeMap(parsedMetadata))
         return map
     }
 

--- a/android/src/main/java/com/tpstreams/TPStreamsRNPlayerView.kt
+++ b/android/src/main/java/com/tpstreams/TPStreamsRNPlayerView.kt
@@ -30,7 +30,7 @@ class TPStreamsRNPlayerView(context: ThemedReactContext) : FrameLayout(context) 
     private var startAt: Long = 0
     private var showDefaultCaptions: Boolean = false
     private var enableDownload: Boolean = false
-    private var downloadMetadata: Map<String, String>? = null
+    private var downloadMetadata: Map<String, Any>? = null
     private var offlineLicenseExpireTime: Long = DEFAULT_OFFLINE_LICENSE_EXPIRE_TIME
     private var accessTokenCallback: ((String) -> Unit)? = null
 
@@ -87,7 +87,7 @@ class TPStreamsRNPlayerView(context: ThemedReactContext) : FrameLayout(context) 
         this.enableDownload = enableDownload
     }
     
-    fun setDownloadMetadata(metadata: Map<String, String>?) {
+    fun setDownloadMetadata(metadata: Map<String, Any>?) {
         this.downloadMetadata = metadata
     }
     
@@ -116,7 +116,7 @@ class TPStreamsRNPlayerView(context: ThemedReactContext) : FrameLayout(context) 
                 startAt,
                 enableDownload, 
                 showDefaultCaptions,
-                downloadMetadata,
+                downloadMetadata?.mapValues { it.value.toString() },
                 offlineLicenseExpireTime
             )
             

--- a/ios/TPStreamsRNPlayerView.swift
+++ b/ios/TPStreamsRNPlayerView.swift
@@ -184,12 +184,12 @@ class TPStreamsRNPlayerView: UIView {
         TPStreamsDownloadModule.shared?.setAccessTokenDelegate(self)
     }
 
-    private func parseMetadataJSON(from jsonString: NSString?) -> [String: String]? {
+    private func parseMetadataJSON(from jsonString: NSString?) -> [String: Any]? {
         guard let metadataString = jsonString as String? else { return nil }
         
         guard let data = metadataString.data(using: .utf8) else { return nil }
         do {
-            if let json = try JSONSerialization.jsonObject(with: data, options: []) as? [String: String] {
+            if let json = try JSONSerialization.jsonObject(with: data, options: []) as? [String: Any] {
                 return json
             }
         } catch {

--- a/src/TPStreamsDownload.tsx
+++ b/src/TPStreamsDownload.tsx
@@ -11,7 +11,7 @@ export interface DownloadItem {
   downloadedBytes: number;
   progressPercentage: number;
   state: string;
-  metadata: string;
+  metadata: string | Record<string, any>;
 }
 
 export type DownloadProgressChange = DownloadItem;

--- a/src/TPStreamsDownload.tsx
+++ b/src/TPStreamsDownload.tsx
@@ -11,7 +11,7 @@ export interface DownloadItem {
   downloadedBytes: number;
   progressPercentage: number;
   state: string;
-  metadata: string | Record<string, any>;
+  metadata: Record<string, any>;
 }
 
 export type DownloadProgressChange = DownloadItem;

--- a/src/TPStreamsPlayer.tsx
+++ b/src/TPStreamsPlayer.tsx
@@ -40,7 +40,7 @@ export interface TPStreamsPlayerProps extends ViewProps {
   enableDownload?: boolean;
   offlineLicenseExpireTime?: number;
   showDefaultCaptions?: boolean;
-  downloadMetadata?: { [key: string]: string };
+  downloadMetadata?: { [key: string]: any };
   onPlayerStateChanged?: (state: number) => void;
   onIsPlayingChanged?: (isPlaying: boolean) => void;
   onPlaybackSpeedChanged?: (speed: number) => void;


### PR DESCRIPTION
- The metadata field was previously restricted to string-only values, which limited the ability to pass structured data like objects, arrays, or other JSON-serializable types. This change enables richer metadata handling by accepting any JSON-compatible data types, improving flexibility for developers who need to attach complex contextual information to downloads and player configurations.