### PR TITLE
feat(ios): add support for offline DRM license expiry and renewal

### DIFF
--- a/TPStreamsRNPlayerView.podspec
+++ b/TPStreamsRNPlayerView.podspec
@@ -21,7 +21,7 @@ Pod::Spec.new do |s|
       'DEFINES_MODULE' => 'YES',
       'CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES' => 'YES'
     }
-  s.dependency "TPStreamsSDK" , "1.2.10"
+  s.dependency "TPStreamsSDK" , "1.2.11"
 
   
   # Ensure the module is not built as a framework to avoid bridging header conflicts

--- a/ios/TPStreamsRNPlayerView.swift
+++ b/ios/TPStreamsRNPlayerView.swift
@@ -4,6 +4,8 @@ import CoreMedia
 import React
 import AVFoundation
 
+let ERROR_CODE_DRM_LICENSE_EXPIRED = 5100
+
 @objc(TPStreamsRNPlayerView)
 class TPStreamsRNPlayerView: UIView {
 
@@ -21,6 +23,7 @@ class TPStreamsRNPlayerView: UIView {
     private var timeControlStatusObserver: NSKeyValueObservation?
     private var playerStateObserver: NSKeyValueObservation?
     private var setupScheduled = false
+    private var pendingOfflineCredentialsCompletion: ((String?, Double) -> Void)?
     
     @objc var videoId: NSString = ""
     @objc var accessToken: NSString = ""
@@ -142,6 +145,15 @@ class TPStreamsRNPlayerView: UIView {
     
     private func configurePlayerView() {
         guard let player = player else { return }
+        player.onRequestOfflineLicenseRenewal = { [weak self] assetId, completion in
+            guard let self = self else {
+                completion(nil, 0)
+                return
+            }
+            self.sendErrorEvent("Playback error", ERROR_CODE_DRM_LICENSE_EXPIRED, "Offline DRM license expired")
+            self.pendingOfflineCredentialsCompletion = completion
+            self.onAccessTokenExpired?(["videoId": assetId])
+        }
         
         let configBuilder = createPlayerConfigBuilder()
         let playerVC = TPStreamPlayerViewController()
@@ -162,6 +174,10 @@ class TPStreamsRNPlayerView: UIView {
             .setprogressBarThumbColor(.systemBlue)
             .setwatchedProgressTrackColor(.systemBlue)
             .setDownloadMetadata(metadataDict)
+
+        if offlineLicenseExpireTime != nil && offlineLicenseExpireTime > 0 {
+            configBuilder.setLicenseDurationSeconds(offlineLicenseExpireTime)
+        }
         
         if enableDownload {
             configBuilder.showDownloadOption()
@@ -237,6 +253,14 @@ class TPStreamsRNPlayerView: UIView {
                 self?.onPlayerStateChanged?(["playbackState": state])
             }
         }
+    }
+
+    private func sendErrorEvent(_ message: String, _ code: Int, _ details: String) {
+        onError?([
+            "message": message,
+            "code": code,
+            "details": details
+        ])
     }
 
     private func mapPlayerStateToAndroid(_ status: AVPlayer.Status, timeControlStatus: AVPlayer.TimeControlStatus? = nil) -> Int {
@@ -318,6 +342,12 @@ class TPStreamsRNPlayerView: UIView {
     @objc func setNewAccessToken(_ newToken: String) {
         pendingTokenCompletion?(newToken)
         pendingTokenCompletion = nil
+        
+        if let OfflineLicenseRenewalCompletion = pendingOfflineCredentialsCompletion {
+            let duration = offlineLicenseExpireTime
+            OfflineLicenseRenewalCompletion(newToken, duration)
+            pendingOfflineCredentialsCompletion = nil
+        }
     }
 
     override func willMove(toSuperview newSuperview: UIView?) {

--- a/ios/TPStreamsRNPlayerView.swift
+++ b/ios/TPStreamsRNPlayerView.swift
@@ -4,10 +4,10 @@ import CoreMedia
 import React
 import AVFoundation
 
-let ERROR_CODE_DRM_LICENSE_EXPIRED = 5100
-
 @objc(TPStreamsRNPlayerView)
 class TPStreamsRNPlayerView: UIView {
+    
+    private static let errorCodeDRMLicenseExpired = 5100
 
     private enum PlaybackState: Int {
         case idle = 1
@@ -150,7 +150,7 @@ class TPStreamsRNPlayerView: UIView {
                 completion(nil, 0)
                 return
             }
-            self.sendErrorEvent("Playback error", ERROR_CODE_DRM_LICENSE_EXPIRED, "Offline DRM license expired")
+            self.sendErrorEvent("Playback error", Self.errorCodeDRMLicenseExpired, "Offline DRM license expired")
             self.pendingOfflineCredentialsCompletion = completion
             self.onAccessTokenExpired?(["videoId": assetId])
         }
@@ -175,7 +175,7 @@ class TPStreamsRNPlayerView: UIView {
             .setwatchedProgressTrackColor(.systemBlue)
             .setDownloadMetadata(metadataDict)
 
-        if offlineLicenseExpireTime != nil && offlineLicenseExpireTime > 0 {
+        if offlineLicenseExpireTime > 0 {
             configBuilder.setLicenseDurationSeconds(offlineLicenseExpireTime)
         }
         
@@ -343,9 +343,9 @@ class TPStreamsRNPlayerView: UIView {
         pendingTokenCompletion?(newToken)
         pendingTokenCompletion = nil
         
-        if let OfflineLicenseRenewalCompletion = pendingOfflineCredentialsCompletion {
+        if let offlineLicenseRenewalCompletion = pendingOfflineCredentialsCompletion {
             let duration = offlineLicenseExpireTime
-            OfflineLicenseRenewalCompletion(newToken, duration)
+            offlineLicenseRenewalCompletion(newToken, duration)
             pendingOfflineCredentialsCompletion = nil
         }
     }


### PR DESCRIPTION
- Enables automatic license renewal when offline DRM licenses expire, preventing playback failures and ensuring downloaded content remains accessible to users.
- Updated iOSPlayerSDK version