### PR TITLE
fix: Replace currentActivity usage for react native compatibility

### DIFF
--- a/android/src/main/java/com/tpstreams/TPStreamsDownloadModule.kt
+++ b/android/src/main/java/com/tpstreams/TPStreamsDownloadModule.kt
@@ -36,7 +36,7 @@ class TPStreamsDownloadModule(private val reactContext: ReactApplicationContext)
             val metadataString = metadata?.let { org.json.JSONObject(it.toHashMap()).toString() }
             val metadataMap = JsonUtils.jsonStringToMap(metadataString)
 
-            val activity = currentActivity ?: run {
+            val activity =reactApplicationContext.currentActivity?: run {
                 promise.reject("DOWNLOAD_START_ERROR", "No current activity available")
                 return
             }


### PR DESCRIPTION
- react native deprecated currentActivity in 0.80
- direct access to currentActivity removed in 0.81
- use reactApplicationContext.currentActivity instead
- fixes build issues on react native ≥ 0.81