### PR TITLE
fix(android): recover from dead DownloadManager HandlerThread after service restart

### DIFF
--- a/android/src/main/java/com/tpstreams/TPStreamsDownloadModule.kt
+++ b/android/src/main/java/com/tpstreams/TPStreamsDownloadModule.kt
@@ -17,9 +17,10 @@ import com.tpstreams.player.download.DownloadItem
 @OptIn(UnstableApi::class)
 class TPStreamsDownloadModule(private val reactContext: ReactApplicationContext) : ReactContextBaseJavaModule(reactContext), DownloadClient.Listener {
 
-    private val downloadClient: DownloadClient by lazy {
-        DownloadClient.getInstance(reactContext)
-    }
+    // Computed property — always returns the current singleton, which may be replaced
+    // by ensureDownloadManagerHealthy() in TPStreamsRNPlayerView after a service restart.
+    private val downloadClient: DownloadClient
+        get() = DownloadClient.getInstance(reactContext)
 
     private var isListening = false
 
@@ -61,11 +62,12 @@ class TPStreamsDownloadModule(private val reactContext: ReactApplicationContext)
     @ReactMethod
     fun addDownloadProgressListener(promise: Promise) {
         try {
-            if (!isListening) {
-                downloadClient.addListener(this)
-                isListening = true
-                Log.d(TAG, "Started listening for download progress")
-            }
+            // Always call addListener — DownloadClient.listeners is a Set so duplicates on
+            // the same instance are ignored. After a DownloadClient singleton reset (caused
+            // by ensureDownloadManagerHealthy), the new instance needs this listener added.
+            downloadClient.addListener(this)
+            isListening = true
+            Log.d(TAG, "Started listening for download progress")
             promise.resolve(null)
         } catch (e: Exception) {
             Log.e(TAG, "Error starting progress listener: ${e.message}", e)

--- a/android/src/main/java/com/tpstreams/TPStreamsRNPlayerView.kt
+++ b/android/src/main/java/com/tpstreams/TPStreamsRNPlayerView.kt
@@ -16,6 +16,12 @@ import androidx.annotation.OptIn
 import androidx.media3.common.util.UnstableApi
 import android.media.MediaCodec
 import android.view.View.MeasureSpec
+import androidx.media3.database.DatabaseProvider
+import androidx.media3.datasource.DataSource
+import androidx.media3.datasource.DefaultDataSource
+import androidx.media3.datasource.cache.Cache
+import androidx.media3.exoplayer.offline.DownloadManager
+import java.util.concurrent.ExecutorService
 
 @OptIn(UnstableApi::class)
 class TPStreamsRNPlayerView(context: ThemedReactContext) : FrameLayout(context) {
@@ -139,6 +145,8 @@ class TPStreamsRNPlayerView(context: ThemedReactContext) : FrameLayout(context) 
     fun tryCreatePlayer() {
         if (videoId.isNullOrEmpty() || accessToken.isNullOrEmpty()) return
         if (player != null) return
+
+        ensureDownloadManagerHealthy()
 
         try {
             player = TPStreamsPlayer.create(
@@ -270,6 +278,87 @@ class TPStreamsRNPlayerView(context: ThemedReactContext) : FrameLayout(context) 
         super.onDetachedFromWindow()
         playerView.player = null
         player?.pause()
+    }
+
+    /**
+     * Workaround for a bug in TPStreamsAndroidPlayer: DownloadController.isInitialized is never
+     * reset to false even after TPSDownloadService.onDestroy() calls DownloadManager.release(),
+     * which kills its internal HandlerThread. On the next download attempt, the stale
+     * DownloadManager is reused and sending a message to its dead handler throws:
+     *   IllegalStateException: Handler {…} sending message to a Handler on a dead thread
+     *
+     * Fix: detect the dead HandlerThread via reflection. If dead, replace the DownloadManager
+     * inside DownloadController with a fresh instance that reuses the existing SimpleCache
+     * (we cannot recreate SimpleCache — a file lock prevents opening the same directory twice).
+     * Then reset the DownloadClient singleton so it binds to the new DownloadManager.
+     */
+    @OptIn(UnstableApi::class)
+    private fun ensureDownloadManagerHealthy() {
+        try {
+            val ctrlClass = Class.forName("com.tpstreams.player.download.DownloadController")
+            val instance = ctrlClass.getDeclaredField("INSTANCE").apply { isAccessible = true }.get(null) ?: return
+
+            val isInitField = ctrlClass.getDeclaredField("isInitialized").apply { isAccessible = true }
+            if (!(isInitField.get(instance) as Boolean)) return // not yet initialized, TPStreamsPlayer.create will init it
+
+            val dmField = ctrlClass.getDeclaredField("downloadManager").apply { isAccessible = true }
+            val dm = dmField.get(instance) ?: return
+
+            if (isDownloadManagerAlive(dm)) return // healthy, nothing to do
+
+            Log.w("TPStreamsRNPlayerView", "DownloadManager HandlerThread is dead — reinitializing with fresh instance")
+
+            // Reuse existing components; SimpleCache must not be recreated (file lock)
+            val dbProvider = ctrlClass.getDeclaredField("databaseProvider").apply { isAccessible = true }.get(instance) as? DatabaseProvider ?: return
+            val cache = ctrlClass.getDeclaredField("downloadCache").apply { isAccessible = true }.get(instance) as? Cache ?: return
+            val httpDsf = ctrlClass.getDeclaredField("httpDataSourceFactory").apply { isAccessible = true }.get(instance) as? DataSource.Factory ?: return
+            val executor = ctrlClass.getDeclaredField("downloadExecutor").apply { isAccessible = true }.get(instance) as? ExecutorService ?: return
+
+            val appCtx = context.applicationContext
+            val newDm = DownloadManager(
+                appCtx, dbProvider, cache,
+                DefaultDataSource.Factory(appCtx, httpDsf),
+                executor
+            ).apply { maxParallelDownloads = 3 }
+
+            dmField.set(instance, newDm)
+            Log.d("TPStreamsRNPlayerView", "DownloadController: fresh DownloadManager installed")
+
+            resetDownloadClientSingleton()
+
+        } catch (e: Exception) {
+            Log.w("TPStreamsRNPlayerView", "ensureDownloadManagerHealthy: ${e.message}")
+        }
+    }
+
+    private fun isDownloadManagerAlive(dm: Any): Boolean {
+        return try {
+            val handlerField = dm.javaClass.getDeclaredField("internalHandler").apply { isAccessible = true }
+            val handler = handlerField.get(dm) ?: return false
+            var clz: Class<*>? = handler.javaClass
+            var mLooperField: java.lang.reflect.Field? = null
+            while (clz != null && mLooperField == null) {
+                try { mLooperField = clz.getDeclaredField("mLooper").apply { isAccessible = true } }
+                catch (_: NoSuchFieldException) { clz = clz.superclass }
+            }
+            val looper = mLooperField?.get(handler) as? android.os.Looper
+            looper?.thread?.isAlive == true
+        } catch (e: Exception) {
+            // If we can't determine liveness, assume alive — conservative, avoids spurious reinit
+            Log.w("TPStreamsRNPlayerView", "isDownloadManagerAlive: can't determine, assuming alive: ${e.message}")
+            true
+        }
+    }
+
+    private fun resetDownloadClientSingleton() {
+        try {
+            val clientClass = Class.forName("com.tpstreams.player.download.DownloadClient")
+            val instanceField = clientClass.getDeclaredField("instance").apply { isAccessible = true }
+            instanceField.set(null, null)
+            Log.d("TPStreamsRNPlayerView", "DownloadClient: singleton reset for fresh binding")
+        } catch (e: Exception) {
+            Log.w("TPStreamsRNPlayerView", "resetDownloadClientSingleton: ${e.message}")
+        }
     }
 
     fun releasePlayer() {


### PR DESCRIPTION
## Problem

After a download completes (or fails), `TPSDownloadService.onDestroy()` calls `DownloadManager.release()`, which stops the internal `HandlerThread`. However, `DownloadController.isInitialized` is **never reset to `false`**, so the next call to `getDownloadManager()` returns the released (dead) instance.

The next download attempt tries to post a message to the dead handler and throws:

```
java.lang.IllegalStateException: Handler {e650204} sending message to a Handler on a dead thread
    at DownloadManager$InternalHandler.putDownload(DownloadManager.java:1237)
```

This makes downloads unreliable after the first session — the download notification appears but no progress is made and the download never completes.

## Root cause

`DownloadController` (Kotlin `object` singleton) sets `isInitialized = true` on first use but never clears it after `DownloadManager.release()`. The `DownloadManager`'s internal `HandlerThread` is dead, but the controller keeps returning the stale instance.

## Fix

### `TPStreamsRNPlayerView.kt`

Added `ensureDownloadManagerHealthy()`, called at the top of `tryCreatePlayer()` before each player creation:

- Uses reflection to access `DownloadController.downloadManager` and walk to its `internalHandler`'s Looper thread.
- If the thread is **dead**: creates a fresh `DownloadManager` reusing the existing `SimpleCache`, `DatabaseProvider`, `DataSource.Factory`, and `ExecutorService`. The `SimpleCache` **must** be reused — a file lock prevents opening the same cache directory twice.
- Replaces `DownloadController.downloadManager` with the fresh instance.
- Calls `resetDownloadClientSingleton()` to null out `DownloadClient.instance` so the next `getInstance()` call binds to the new `DownloadManager`.
- If any reflection field is not found (e.g. renamed in a future Media3 version), the method catches the exception and returns without reinitialising — safe, conservative fallback.

### `TPStreamsDownloadModule.kt`

- Changed `downloadClient` from a `lazy val` to a computed property (`get() = DownloadClient.getInstance(...)`), so it always returns the **current** singleton rather than the one captured at first access.
- Removed the `isListening` guard in `addDownloadProgressListener` so the listener is always registered with the current `DownloadClient` instance after a singleton reset. `DownloadClient.listeners` is a `Set`, so adding the same listener to the same instance is a no-op.

## Verification

Tested on OnePlus 6T (Android 10, Media3 1.7.1):

1. Tapped download on a Widevine-protected DASH stream.
2. Download completed successfully.
3. Killed the app, reopened, tapped download on a different video — completed without the `IllegalStateException`.
4. Disabled network on device — offline DRM playback confirmed.
5. Player settings showed **"Downloaded"** badge.

## Notes

- This fix is in the React Native bridge layer (`react-native-tpstreams`). The root cause lives in `TPStreamsAndroidPlayer`'s `DownloadController` — ideally `isInitialized` would be reset in `DownloadService.onDestroy()` in the native SDK, which would make this bridge-layer workaround unnecessary.
- The reflection targets (`DownloadController.INSTANCE`, `isInitialized`, `downloadManager`, `databaseProvider`, `downloadCache`, `httpDataSourceFactory`, `downloadExecutor`, `DownloadClient.instance`, `DownloadManager.internalHandler`) match `TPStreamsAndroidPlayer` v1.1.8. If field names change in future SDK versions, `ensureDownloadManagerHealthy` catches `NoSuchFieldException` and exits cleanly.