### PR TITLE
feat: pass offlineLicenseExpireTime through startDownload API

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -3,4 +3,4 @@ Tpstreams_minSdkVersion=24
 Tpstreams_targetSdkVersion=34
 Tpstreams_compileSdkVersion=35
 Tpstreams_ndkVersion=27.1.12297006
-Tpstreams_tpstreamsAndroidPlayerVersion=1.2.4
+Tpstreams_tpstreamsAndroidPlayerVersion=1.2.5

--- a/android/src/main/java/com/tpstreams/LicenseDurationUtils.kt
+++ b/android/src/main/java/com/tpstreams/LicenseDurationUtils.kt
@@ -1,0 +1,12 @@
+package com.tpstreams
+
+object LicenseDurationUtils {
+    const val DEFAULT_LICENSE_EXPIRY_SECONDS = 15L * 24 * 60 * 60 // 15 days
+
+    fun sanitize(value: Long?): Long {
+        if (value == null || value <= 0L) {
+            return DEFAULT_LICENSE_EXPIRY_SECONDS
+        }
+        return minOf(value, DEFAULT_LICENSE_EXPIRY_SECONDS)
+    }
+}

--- a/android/src/main/java/com/tpstreams/TPStreamsDownloadModule.kt
+++ b/android/src/main/java/com/tpstreams/TPStreamsDownloadModule.kt
@@ -33,6 +33,7 @@ class TPStreamsDownloadModule(private val reactContext: ReactApplicationContext)
         accessToken: String,
         resolution: String?,
         metadata: ReadableMap?,
+        offlineLicenseExpireTime: Double?,
         promise: Promise
     ) {
         try {
@@ -49,7 +50,8 @@ class TPStreamsDownloadModule(private val reactContext: ReactApplicationContext)
                 videoId,
                 accessToken,
                 resolution,
-                metadataMap
+                metadataMap,
+                offlineLicenseExpireTime?.toLong()
             )
             promise.resolve(null)
         } catch (e: Exception) {

--- a/android/src/main/java/com/tpstreams/TPStreamsDownloadModule.kt
+++ b/android/src/main/java/com/tpstreams/TPStreamsDownloadModule.kt
@@ -51,7 +51,7 @@ class TPStreamsDownloadModule(private val reactContext: ReactApplicationContext)
                 accessToken,
                 resolution,
                 metadataMap,
-                offlineLicenseExpireTime?.toLong()
+                LicenseDurationUtils.sanitize(offlineLicenseExpireTime?.toLong())
             )
             promise.resolve(null)
         } catch (e: Exception) {

--- a/android/src/main/java/com/tpstreams/TPStreamsRNPlayerView.kt
+++ b/android/src/main/java/com/tpstreams/TPStreamsRNPlayerView.kt
@@ -24,7 +24,6 @@ class TPStreamsRNPlayerView(context: ThemedReactContext) : FrameLayout(context) 
     private val reactContext: ReactContext = context
 
     companion object {
-        private const val DEFAULT_OFFLINE_LICENSE_EXPIRE_TIME = 15L * 24L * 60L * 60L // 15 days in seconds
         private const val ERROR_CODE_PLAYER_CREATION_FAILED = 1001
         private const val ERROR_CODE_DRM_LICENSE_EXPIRED = 5001
     }
@@ -37,7 +36,7 @@ class TPStreamsRNPlayerView(context: ThemedReactContext) : FrameLayout(context) 
     private var startInFullscreen: Boolean = false
     private var enableDownload: Boolean = false
     private var downloadMetadata: Map<String, Any>? = null
-    private var offlineLicenseExpireTime: Long = DEFAULT_OFFLINE_LICENSE_EXPIRE_TIME
+    private var offlineLicenseExpireTime: Long = LicenseDurationUtils.DEFAULT_LICENSE_EXPIRY_SECONDS
     private var accessTokenCallback: ((String) -> Unit)? = null
     private var isLayoutUpdatePosted = false
 
@@ -125,7 +124,7 @@ class TPStreamsRNPlayerView(context: ThemedReactContext) : FrameLayout(context) 
     }
     
     fun setOfflineLicenseExpireTime(expireTime: Long?) {
-        this.offlineLicenseExpireTime = sanitizeLicenseDuration(expireTime)
+        this.offlineLicenseExpireTime = LicenseDurationUtils.sanitize(expireTime)
     }
     
     fun setNewAccessToken(newToken: String) {
@@ -280,12 +279,5 @@ class TPStreamsRNPlayerView(context: ThemedReactContext) : FrameLayout(context) 
         }
         player = null
         accessTokenCallback = null
-    }
-
-    private fun sanitizeLicenseDuration(value: Long?): Long {
-        if (value == null || value <= 0L) {
-            return DEFAULT_OFFLINE_LICENSE_EXPIRE_TIME
-        }
-        return minOf(value, DEFAULT_OFFLINE_LICENSE_EXPIRE_TIME)
     }
 }

--- a/ios/LicenseDurationUtils.swift
+++ b/ios/LicenseDurationUtils.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+enum LicenseDurationUtils {
+    static let DEFAULT_LICENSE_EXPIRY_SECONDS: Double = 15 * 24 * 60 * 60 // 15 days
+
+    static func sanitize(_ value: Double) -> Double {
+        guard value > 0 else { return DEFAULT_LICENSE_EXPIRY_SECONDS }
+        return min(value, DEFAULT_LICENSE_EXPIRY_SECONDS)
+    }
+}

--- a/ios/TPStreamsDownloadModule.mm
+++ b/ios/TPStreamsDownloadModule.mm
@@ -15,6 +15,7 @@ RCT_EXTERN_METHOD(startDownload:(NSString *)videoId
                   accessToken:(NSString *)accessToken
                   resolution:(NSString *)resolution
                   metadata:(NSDictionary *)metadata
+                  offlineLicenseExpireTime:(NSNumber *)offlineLicenseExpireTime
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject)
 

--- a/ios/TPStreamsDownloadModule.swift
+++ b/ios/TPStreamsDownloadModule.swift
@@ -72,7 +72,9 @@ class TPStreamsDownloadModule: RCTEventEmitter, TPStreamsDownloadDelegate {
                 resolution: res,
                 allowResolutionFallback: true,
                 metadata: metadataDict,
-                offlineLicenseDurationSeconds: offlineLicenseExpireTime?.doubleValue,
+                offlineLicenseDurationSeconds: LicenseDurationUtils.sanitize(
+                    offlineLicenseExpireTime?.doubleValue ?? 0
+                ),
                 presentingViewController: presentingVC,
                 completion: nil
             )

--- a/ios/TPStreamsDownloadModule.swift
+++ b/ios/TPStreamsDownloadModule.swift
@@ -19,7 +19,7 @@ protocol TokenRequestDelegate: AnyObject {
 
 @objc(TPStreamsDownload)
 class TPStreamsDownloadModule: RCTEventEmitter, TPStreamsDownloadDelegate {
-    
+
     private let downloadManager = TPStreamsDownloadManager.shared
     private var isListening = false
     private var tokenDelegate: TokenRequestDelegate?
@@ -50,15 +50,32 @@ class TPStreamsDownloadModule: RCTEventEmitter, TPStreamsDownloadDelegate {
     }
     
     @objc
-    func startDownload(_ videoId: String, accessToken: String, resolution: String?, metadata: NSDictionary?, resolver resolve: @escaping RCTPromiseResolveBlock, rejecter reject: @escaping RCTPromiseRejectBlock) {
+    func startDownload(
+        _ videoId: String,
+        accessToken: String,
+        resolution: String?,
+        metadata: NSDictionary?,
+        offlineLicenseExpireTime: NSNumber?,
+        resolver resolve: @escaping RCTPromiseResolveBlock,
+        rejecter reject: @escaping RCTPromiseRejectBlock
+    ) {
         DispatchQueue.main.async { [weak self] in
             guard let self = self else { return }
             
             let metadataDict = metadata as? [String: Any]
             let res = (resolution?.isEmpty ?? true) ? nil : resolution
             let presentingVC = (res == nil) ? RCTPresentedViewController() : nil
-            
-            self.downloadManager.startDownload(assetID: videoId, accessToken: accessToken, resolution: res, allowResolutionFallback: true, metadata: metadataDict, presentingViewController: presentingVC, completion: nil)
+    
+            self.downloadManager.startDownload(
+                assetID: videoId,
+                accessToken: accessToken,
+                resolution: res,
+                allowResolutionFallback: true,
+                metadata: metadataDict,
+                offlineLicenseDurationSeconds: offlineLicenseExpireTime?.doubleValue,
+                presentingViewController: presentingVC,
+                completion: nil
+            )
             resolve(nil)
         }
     }

--- a/ios/TPStreamsRNPlayerView.swift
+++ b/ios/TPStreamsRNPlayerView.swift
@@ -15,8 +15,6 @@ class TPStreamsRNPlayerView: UIView {
         case ready = 3
         case ended = 4
     }
-
-    private static let maxOfflineLicenseDuration: Double = 15 * 24 * 60 * 60
     
     private var player: TPAVPlayer?
     private var playerViewController: TPStreamPlayerViewController?
@@ -34,7 +32,7 @@ class TPStreamsRNPlayerView: UIView {
     private var setupScheduled = false
     private var isPlayerReady = false
     private var pendingOfflineCredentialsCompletion: ((String?, Double) -> Void)?
-    private var _offlineLicenseExpireTime: Double = TPStreamsRNPlayerView.maxOfflineLicenseDuration
+    private var _offlineLicenseExpireTime: Double = LicenseDurationUtils.DEFAULT_LICENSE_EXPIRY_SECONDS
     
     @objc var videoId: NSString = ""
     @objc var accessToken: NSString = ""
@@ -43,7 +41,7 @@ class TPStreamsRNPlayerView: UIView {
     @objc var enableDownload: Bool = false
     @objc var offlineLicenseExpireTime: Double {
         get { _offlineLicenseExpireTime }
-        set { _offlineLicenseExpireTime = TPStreamsRNPlayerView.sanitizeLicenseDuration(newValue) }
+        set { _offlineLicenseExpireTime = LicenseDurationUtils.sanitize(newValue) }
     }
     @objc var showDefaultCaptions: Bool = false
     @objc var startInFullscreen: Bool = false
@@ -355,11 +353,6 @@ class TPStreamsRNPlayerView: UIView {
         DispatchQueue.main.async {
             self.loadingIndicator.stopAnimating()
         }
-    }
-
-    private static func sanitizeLicenseDuration(_ value: Double) -> Double {
-        guard value > 0 else { return maxOfflineLicenseDuration }
-        return min(value, maxOfflineLicenseDuration)
     }
 
     private func parseMetadataJSON(from jsonString: NSString?) -> [String: Any]? {

--- a/src/TPStreamsDownload.tsx
+++ b/src/TPStreamsDownload.tsx
@@ -35,13 +35,15 @@ export function startDownload(
   videoId: string,
   accessToken: string,
   resolution: string | null = null,
-  metadata: Record<string, any> | null = null
+  metadata: Record<string, any> | null = null,
+  offlineLicenseExpireTime?: number
 ): Promise<void> {
   return TPStreamsDownload.startDownload(
     videoId,
     accessToken,
     resolution,
-    metadata
+    metadata,
+    offlineLicenseExpireTime ?? null
   );
 }
 


### PR DESCRIPTION
## Summary
- Wire optional `offlineLicenseExpireTime` from JS `startDownload` through iOS and Android native download modules
- Bump `TPStreamsAndroidPlayer` to **1.2.5** (exposes `offlineLicenseExpireTime` on public `DownloadClient.startDownload`, from [TPStreamsAndroidPlayer#116](https://github.com/testpress/TPStreamsAndroidPlayer/pull/116))