### PR TITLE
fix: show captions menu on iOS by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ import { TPStreamsPlayerView } from "react-native-tpstreams";
 | `startAt` | `number` | No | Start position in seconds (default: 0) |
 | `enableDownload` | `boolean` | No | Enable download functionality (default: false) |
 | `offlineLicenseExpireTime` | `number` | No | License expiration in seconds (default: 15 days) |
-| `showDefaultCaptions` | `boolean` | No | Show captions if available (default: false) |
+| `showDefaultCaptions` | `boolean` | No | Auto-select first subtitle track on load; the captions menu is always available (default: false) |
 | `startInFullscreen` | `boolean` | No | Start the player in fullscreen mode (default: false) |
 | `downloadMetadata` | `object` | No | Custom metadata for downloads |
 

--- a/ios/TPStreamsRNPlayerView.swift
+++ b/ios/TPStreamsRNPlayerView.swift
@@ -199,8 +199,10 @@ class TPStreamsRNPlayerView: UIView {
             configBuilder.showDownloadOption()
         }
         
+        // Always expose the captions option, matching Android where the menu is
+        // always shown. The prop only controls auto-selecting the first track.
+        configBuilder.enableCaptions(true)
         if showDefaultCaptions {
-            configBuilder.enableCaptions(true)
             configBuilder.autoSelectFirstSubtitle(true)
         }
 


### PR DESCRIPTION
- Captions menu was hidden on iOS unless `showDefaultCaptions` was false.
- This caused inconsistent caption behavior between iOS and Android.
- Captions menu is now always shown, while `showDefaultCaptions` only controls auto-selection.