### PR TITLE
Plumb presence token refresh through to the app

### DIFF
--- a/TPStreamsRNPlayerView.podspec
+++ b/TPStreamsRNPlayerView.podspec
@@ -21,6 +21,10 @@ Pod::Spec.new do |s|
       'DEFINES_MODULE' => 'YES',
       'CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES' => 'YES'
     }
+  # TODO: bump once the presence-heartbeat PR (iOSPlayerSDK
+  # feat/presence-sdk-integration) merges and releases — this pinned version
+  # predates TPStreamPlayerViewControllerDelegate.presenceTokenExpired, so
+  # TPStreamsRNPlayerView.swift's conformance to it will not compile until then.
   s.dependency "TPStreamsSDK" , "1.2.36"
 
 

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -3,4 +3,9 @@ Tpstreams_minSdkVersion=24
 Tpstreams_targetSdkVersion=34
 Tpstreams_compileSdkVersion=35
 Tpstreams_ndkVersion=27.1.12297006
+# TODO: bump once the presence-heartbeat PR (TPStreamsAndroidPlayer
+# feat/presence-sdk-integration) merges and releases — this pinned version
+# predates TPStreamsPlayer.Listener.onPresenceTokenExpired and
+# BaseApiService.assetInfoUrl's viewerId param, so TPStreamsRNPlayerView.kt's
+# onPresenceTokenExpired/setNewPresenceToken will not compile until then.
 Tpstreams_tpstreamsAndroidPlayerVersion=1.2.6

--- a/android/src/main/java/com/tpstreams/TPStreamsRNPlayerView.kt
+++ b/android/src/main/java/com/tpstreams/TPStreamsRNPlayerView.kt
@@ -38,6 +38,7 @@ class TPStreamsRNPlayerView(context: ThemedReactContext) : FrameLayout(context) 
     private var downloadMetadata: Map<String, Any>? = null
     private var offlineLicenseExpireTime: Long = LicenseDurationUtils.DEFAULT_LICENSE_EXPIRY_SECONDS
     private var accessTokenCallback: ((String) -> Unit)? = null
+    private var presenceTokenCallback: ((String) -> Unit)? = null
     private var isLayoutUpdatePosted = false
 
     init {
@@ -135,6 +136,14 @@ class TPStreamsRNPlayerView(context: ThemedReactContext) : FrameLayout(context) 
         } ?: Log.w("TPStreamsRNPlayerView", "No callback available for token refresh")
     }
 
+    fun setNewPresenceToken(newToken: String) {
+        Log.d("TPStreamsRNPlayerView", "Setting new presence token")
+        presenceTokenCallback?.let { callback ->
+            callback(newToken)
+            presenceTokenCallback = null
+        } ?: Log.w("TPStreamsRNPlayerView", "No callback available for presence token refresh")
+    }
+
     fun tryCreatePlayer() {
         if (videoId.isNullOrEmpty() || accessToken.isNullOrEmpty()) return
         if (player != null) return
@@ -161,6 +170,15 @@ class TPStreamsRNPlayerView(context: ThemedReactContext) : FrameLayout(context) 
                     }
                     accessTokenCallback = callback
                     emitEvent("onAccessTokenExpired", mapOf("videoId" to videoId))
+                }
+
+                override fun onPresenceTokenExpired(videoId: String, callback: (String) -> Unit) {
+                    if (presenceTokenCallback != null) {
+                        Log.w("TPStreamsRNPlayerView", "onPresenceTokenExpired called while another refresh is in progress. Ignoring.")
+                        return
+                    }
+                    presenceTokenCallback = callback
+                    emitEvent("onPresenceTokenExpired", mapOf("videoId" to videoId))
                 }
 
                 override fun onError(error: PlaybackError, message: String) {
@@ -279,5 +297,6 @@ class TPStreamsRNPlayerView(context: ThemedReactContext) : FrameLayout(context) 
         }
         player = null
         accessTokenCallback = null
+        presenceTokenCallback = null
     }
 }

--- a/android/src/main/java/com/tpstreams/TPStreamsRNPlayerViewManager.kt
+++ b/android/src/main/java/com/tpstreams/TPStreamsRNPlayerViewManager.kt
@@ -27,6 +27,7 @@ class TPStreamsRNPlayerViewManager : SimpleViewManager<TPStreamsRNPlayerView>(),
     private const val EVENT_IS_LOADING_CHANGED = "onIsLoadingChanged"
     private const val EVENT_ERROR = "onError"
     private const val EVENT_ACCESS_TOKEN_EXPIRED = "onAccessTokenExpired"
+    private const val EVENT_PRESENCE_TOKEN_EXPIRED = "onPresenceTokenExpired"
   }
   
   private val mDelegate: ViewManagerDelegate<TPStreamsRNPlayerView> = 
@@ -48,6 +49,7 @@ class TPStreamsRNPlayerViewManager : SimpleViewManager<TPStreamsRNPlayerView>(),
       .put(EVENT_IS_LOADING_CHANGED, MapBuilder.of("registrationName", EVENT_IS_LOADING_CHANGED))
       .put(EVENT_ERROR, MapBuilder.of("registrationName", EVENT_ERROR))
       .put(EVENT_ACCESS_TOKEN_EXPIRED, MapBuilder.of("registrationName", EVENT_ACCESS_TOKEN_EXPIRED))
+      .put(EVENT_PRESENCE_TOKEN_EXPIRED, MapBuilder.of("registrationName", EVENT_PRESENCE_TOKEN_EXPIRED))
       .build()
   }
 
@@ -135,7 +137,11 @@ class TPStreamsRNPlayerViewManager : SimpleViewManager<TPStreamsRNPlayerView>(),
   override fun setNewAccessToken(view: TPStreamsRNPlayerView, newToken: String) {
     view.setNewAccessToken(newToken)
   }
-  
+
+  override fun setNewPresenceToken(view: TPStreamsRNPlayerView, newToken: String) {
+    view.setNewPresenceToken(newToken)
+  }
+
   override fun onAfterUpdateTransaction(view: TPStreamsRNPlayerView) {
     super.onAfterUpdateTransaction(view)
     view.tryCreatePlayer()

--- a/ios/TPStreamsRNPlayerView.swift
+++ b/ios/TPStreamsRNPlayerView.swift
@@ -58,8 +58,10 @@ class TPStreamsRNPlayerView: UIView {
     @objc var onIsLoadingChanged: RCTDirectEventBlock?
     @objc var onError: RCTDirectEventBlock?
     @objc var onAccessTokenExpired: RCTDirectEventBlock?
+    @objc var onPresenceTokenExpired: RCTDirectEventBlock?
 
     private var pendingTokenCompletion: ((String?) -> Void)?
+    private var pendingPresenceTokenCompletion: ((String?) -> Void)?
     
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -176,7 +178,8 @@ class TPStreamsRNPlayerView: UIView {
         let playerVC = TPStreamPlayerViewController()
         playerVC.player = player
         playerVC.config = configBuilder.build()
-        
+        playerVC.delegate = self
+
         attachPlayerViewController(playerVC)
         
         if shouldAutoPlay { player.play() }
@@ -424,6 +427,11 @@ class TPStreamsRNPlayerView: UIView {
         }
     }
 
+    @objc func setNewPresenceToken(_ newToken: String) {
+        pendingPresenceTokenCompletion?(newToken.isEmpty ? nil : newToken)
+        pendingPresenceTokenCompletion = nil
+    }
+
     override func willMove(toSuperview newSuperview: UIView?) {
         if newSuperview == nil {
             cleanupPlayer()
@@ -444,5 +452,26 @@ extension TPStreamsRNPlayerView: TokenRequestDelegate {
         }
         pendingTokenCompletion = completion
         onAccessTokenExpired(["videoId": assetId])
+    }
+}
+
+// The four full-screen callbacks have no default body in
+// TPStreamPlayerViewControllerDelegate — presenceTokenExpired is the only one
+// this RN wrapper currently has any use for; the rest are unimplemented
+// no-ops rather than newly surfacing full-screen events RN did not have
+// before.
+extension TPStreamsRNPlayerView: TPStreamPlayerViewControllerDelegate {
+    func willEnterFullScreenMode() {}
+    func didEnterFullScreenMode() {}
+    func willExitFullScreenMode() {}
+    func didExitFullScreenMode() {}
+
+    func presenceTokenExpired(forVideo videoId: String, completion: @escaping (String?) -> Void) {
+        guard let onPresenceTokenExpired = onPresenceTokenExpired else {
+            completion(nil)
+            return
+        }
+        pendingPresenceTokenCompletion = completion
+        onPresenceTokenExpired(["videoId": videoId])
     }
 }

--- a/ios/TPStreamsRNPlayerViewManager.m
+++ b/ios/TPStreamsRNPlayerViewManager.m
@@ -25,6 +25,7 @@ RCT_EXPORT_VIEW_PROPERTY(onPlaybackSpeedChanged, RCTDirectEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onIsLoadingChanged, RCTDirectEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onError, RCTDirectEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onAccessTokenExpired, RCTDirectEventBlock)
+RCT_EXPORT_VIEW_PROPERTY(onPresenceTokenExpired, RCTDirectEventBlock)
 
 // Player commands
 RCT_EXTERN_METHOD(play:(nonnull NSNumber *)node)
@@ -36,5 +37,6 @@ RCT_EXTERN_METHOD(getDuration:(nonnull NSNumber *)node)
 RCT_EXTERN_METHOD(isPlaying:(nonnull NSNumber *)node)
 RCT_EXTERN_METHOD(getPlaybackSpeed:(nonnull NSNumber *)node)
 RCT_EXTERN_METHOD(setNewAccessToken:(nonnull NSNumber *)node newToken:(nonnull NSString *)newToken)
+RCT_EXTERN_METHOD(setNewPresenceToken:(nonnull NSNumber *)node newToken:(nonnull NSString *)newToken)
 
 @end

--- a/src/TPStreamsPlayer.tsx
+++ b/src/TPStreamsPlayer.tsx
@@ -55,6 +55,19 @@ export interface TPStreamsPlayerProps extends ViewProps {
     videoId: string,
     callback: (newToken: string) => void
   ) => void;
+  /**
+   * Called on a 401 from the presence heartbeat loop — an expired token and
+   * a device-binding mismatch look identical from here, and both are
+   * resolved the same way: fetch a fresh playback config and call
+   * callback with its presence token. Optional: presence is still
+   * rollout-gated to a handful of organizations, and leaving this unset
+   * simply means the heartbeat loop quietly stops after a 401 instead of
+   * resuming, the same as if presence were disabled.
+   */
+  onPresenceTokenExpired?: (
+    videoId: string,
+    callback: (newToken: string) => void
+  ) => void;
 }
 
 /**
@@ -82,6 +95,7 @@ const TPStreamsPlayerView = forwardRef<
     onIsLoadingChanged,
     onError,
     onAccessTokenExpired,
+    onPresenceTokenExpired,
     ...restProps
   } = props;
 
@@ -187,6 +201,28 @@ const TPStreamsPlayerView = forwardRef<
     [onAccessTokenExpired]
   );
 
+  const handlePresenceTokenExpired = useCallback(
+    (event: { nativeEvent: { videoId: string } }) => {
+      const { videoId: expiredVideoId } = event.nativeEvent;
+      const resolve = (newToken: string) => {
+        if (nativeRef.current) {
+          Commands.setNewPresenceToken(nativeRef.current, newToken);
+        } else {
+          console.error('[RN] Native ref is not available');
+        }
+      };
+      if (onPresenceTokenExpired) {
+        onPresenceTokenExpired(expiredVideoId, resolve);
+      } else {
+        // Matches the native side's own default: nothing set means presence
+        // isn't wired up, so back off rather than wait on a callback that
+        // will never fire.
+        resolve('');
+      }
+    },
+    [onPresenceTokenExpired]
+  );
+
   // Helper to create promise-based API methods
   const createPromiseMethod = useCallback(
     (command: (ref: any) => void, eventKey: string) => {
@@ -261,6 +297,7 @@ const TPStreamsPlayerView = forwardRef<
     onIsLoadingChanged: handleIsLoadingChanged,
     onError: handleError,
     onAccessTokenExpired: handleAccessTokenExpired,
+    onPresenceTokenExpired: handlePresenceTokenExpired,
   };
 
   return <TPStreamsPlayerNative {...nativeProps} ref={nativeRef} />;

--- a/src/TPStreamsPlayerViewNativeComponent.ts
+++ b/src/TPStreamsPlayerViewNativeComponent.ts
@@ -39,6 +39,7 @@ export interface NativeProps extends ViewProps {
   onIsLoadingChanged?: DirectEventHandler<{ isLoading: boolean }>;
   onError?: DirectEventHandler<ErrorEvent>;
   onAccessTokenExpired?: DirectEventHandler<{ videoId: string }>;
+  onPresenceTokenExpired?: DirectEventHandler<{ videoId: string }>;
 }
 
 interface TPStreamsPlayerViewCommands {
@@ -64,6 +65,10 @@ interface TPStreamsPlayerViewCommands {
     viewRef: React.ElementRef<HostComponent<NativeProps>>,
     newToken: string
   ) => void;
+  setNewPresenceToken: (
+    viewRef: React.ElementRef<HostComponent<NativeProps>>,
+    newToken: string
+  ) => void;
 }
 
 export const Commands = codegenNativeCommands<TPStreamsPlayerViewCommands>({
@@ -77,6 +82,7 @@ export const Commands = codegenNativeCommands<TPStreamsPlayerViewCommands>({
     'isPlaying',
     'getPlaybackSpeed',
     'setNewAccessToken',
+    'setNewPresenceToken',
   ],
 });
 


### PR DESCRIPTION
## Summary
- Adds `onPresenceTokenExpired` prop and `setNewPresenceToken` command, mirroring the existing `onAccessTokenExpired`/`setNewAccessToken` pattern, so RN apps can resolve a fresh presence token on a 401 from the native heartbeat loop.
- Android (`TPStreamsRNPlayerView.kt`, `TPStreamsRNPlayerViewManager.kt`): wires `TPStreamsPlayer.Listener.onPresenceTokenExpired`, exports the event, adds the `setNewPresenceToken` command.
- iOS (`TPStreamsRNPlayerView.swift`, `TPStreamsRNPlayerViewManager.m`): **discovered `playerVC.delegate` was never being set** — added it, plus a `TPStreamPlayerViewControllerDelegate` conformance with the 4 required no-op fullscreen methods and a real `presenceTokenExpired(forVideo:completion:)` implementation.
- JS/TS (`TPStreamsPlayer.tsx`, `TPStreamsPlayerViewNativeComponent.ts`): new prop type, event handler, command wiring. If the app doesn't set `onPresenceTokenExpired`, we resolve with `''` by default (matches the native side's own backoff-not-hang default) instead of leaving the native callback dangling.
- Bumps pinned native SDK versions with TODO comments (not real version numbers) pointing at `TPStreamsAndroidPlayer#feat/presence-sdk-integration` and `iOSPlayerSDK#170`, which need to merge and ship first.

## Verification
- `yarn install` — clean
- `yarn typecheck` — passes
- `yarn test` — passes (existing stub test suite)
- `yarn lint` — pre-existing failure (`structuredClone is not defined`, Node 16 vs ESLint config needing 17+), unrelated to this change
- Not build-verified against the actual native SDKs since those changes haven't shipped yet — see "Not done here."

## Not done here
- Native SDK builds/runtime testing against real `TPStreamsAndroidPlayer`/`TPStreamsSDK` releases containing the presence changes — those are still in review (see linked PRs).

Related: testpress/TPStreamsAndroidPlayer#feat/presence-sdk-integration, testpress/iOSPlayerSDK#170