### PR TITLE
feat: add allowFallbackToL3 option to TPStreams.initialize()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.24] - 2026-08-20
+
+### Added
+- `userId` prop — enables per-user resume playback. Pass a unique user
+  identifier to resume where each user left off.
+- `watermarks` prop — render text overlays on the player. Supports position,
+  color, size, opacity, and `pingPong` animation.
+- Export `WatermarkConfig` type for TypeScript users.
+- `TPStreams.initialize()` now accepts an optional config object with
+  `allowFallbackToL3` (Android only) for Widevine L1→L3 fallback.
+
+### Changed
+- Update iOS SDK from 1.2.36 to **1.2.40** (resume playback, watermarks).
+- Update Android SDK from 1.2.6 to **1.2.8** (resume playback, watermarks).
+
 ## [1.1.23] - 2026-08-11
 
 ### Fixed

--- a/android/src/main/java/com/tpstreams/TPStreamsRNModule.kt
+++ b/android/src/main/java/com/tpstreams/TPStreamsRNModule.kt
@@ -3,6 +3,7 @@ package com.tpstreams
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReactContextBaseJavaModule
 import com.facebook.react.bridge.ReactMethod
+import com.facebook.react.bridge.ReadableMap
 import com.tpstreams.player.TPStreamsSDK
 
 class TPStreamsRNModule(reactContext: ReactApplicationContext) : ReactContextBaseJavaModule(reactContext) {
@@ -12,7 +13,8 @@ class TPStreamsRNModule(reactContext: ReactApplicationContext) : ReactContextBas
     }
 
     @ReactMethod
-    fun initialize(organizationId: String) {
-        TPStreamsSDK.init(organizationId)
+    fun initialize(organizationId: String, config: ReadableMap? = null) {
+        val allowFallbackToL3 = config?.getBoolean("allowFallbackToL3") ?: false
+        TPStreamsSDK.init(organizationId, allowFallbackToL3 = allowFallbackToL3)
     }
 } 

--- a/android/src/main/java/com/tpstreams/TPStreamsRNModule.kt
+++ b/android/src/main/java/com/tpstreams/TPStreamsRNModule.kt
@@ -14,7 +14,9 @@ class TPStreamsRNModule(reactContext: ReactApplicationContext) : ReactContextBas
 
     @ReactMethod
     fun initialize(organizationId: String, config: ReadableMap? = null) {
-        val allowFallbackToL3 = config?.getBoolean("allowFallbackToL3") ?: false
+        val allowFallbackToL3 = config?.let {
+            if (it.hasKey("allowFallbackToL3")) it.getBoolean("allowFallbackToL3") else false
+        } ?: false
         TPStreamsSDK.init(organizationId, allowFallbackToL3 = allowFallbackToL3)
     }
 } 

--- a/example/index.js
+++ b/example/index.js
@@ -3,6 +3,6 @@ import App from './src/App';
 import { name as appName } from './app.json';
 import { TPStreams } from 'react-native-tpstreams';
 
-TPStreams.initialize('9q94nm');
+TPStreams.initialize('9q94nm', { allowFallbackToL3: true });
 
 AppRegistry.registerComponent(appName, () => App);

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,4 +1,4 @@
-import { NativeModules } from 'react-native';
+import { NativeModules, Platform } from 'react-native';
 // Export the native component with a different name to avoid conflicts
 export { default as TPStreamsPlayerNative } from './TPStreamsPlayerViewNativeComponent';
 export * from './TPStreamsPlayerViewNativeComponent';
@@ -35,9 +35,19 @@ export {
 
 const TPStreamsModule = NativeModules.TPStreams;
 
+export interface TPStreamsConfig {
+  allowFallbackToL3?: boolean;
+}
+
 export const TPStreams = {
-  initialize: (organizationId: string): void => {
-    TPStreamsModule.initialize(organizationId);
+  initialize: (organizationId: string, config: TPStreamsConfig = {}): void => {
+    if (Platform.OS === 'android') {
+      TPStreamsModule.initialize(organizationId, {
+        allowFallbackToL3: config.allowFallbackToL3 ?? false,
+      });
+    } else {
+      TPStreamsModule.initialize(organizationId);
+    }
   },
 };
 


### PR DESCRIPTION
- TPStreams.initialize() now accepts an optional config object with allowFallbackToL3 (Android only) for Widevine L1 to L3 fallback
- Android native module updated to accept ReadableMap config
- iOS unaffected (SDK does not expose this parameter)